### PR TITLE
Add (Extract/Append)SubMessage to DataHelpers

### DIFF
--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
@@ -29,11 +29,7 @@ void UROSMsgPoseStamped::ToData(ROSData& OutMessage) const
 
 bool UROSMsgPoseStamped::FromData(const ROSData& Message)
 {
-	if(!Header) Header = NewObject<UROSMsgHeader>(this);
-	if(!Pose) Pose = NewObject<UROSMsgPose>(this);
-	
-	ROSData SubElementHeader;
-	ROSData SubElementPose;
-	return DataHelpers::ExtractSubDocument(Message, "header", SubElementHeader) && Header->FromData(SubElementHeader)
-	&& DataHelpers::ExtractSubDocument(Message, "pose", SubElementPose) && Pose->FromData(SubElementPose);
+	return
+		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
+		DataHelpers::ExtractSubMessage(Message, "pose", Pose);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
@@ -19,12 +19,8 @@ UROSMsgPoseStamped* UROSMsgPoseStamped::CreateEmpty()
 
 void UROSMsgPoseStamped::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementHeader;
-	ROSData SubElementPose;
-	Header->ToData(SubElementHeader);
-	Pose->ToData(SubElementPose);
-	DataHelpers::AppendSubDocument(OutMessage,  "header", SubElementHeader);
-	DataHelpers::AppendSubDocument(OutMessage,  "pose", SubElementPose);
+	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
+	DataHelpers::AppendSubMessage(OutMessage, "pose", Pose);
 }
 
 bool UROSMsgPoseStamped::FromData(const ROSData& Message)

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
@@ -59,11 +59,8 @@ void UROSMsgPoseWithCovariance::ToData(ROSData& OutMessage) const
 
 bool UROSMsgPoseWithCovariance::FromData(const ROSData& Message)
 {
-	if(!Pose) Pose = NewObject<UROSMsgPose>(this);
-	
-	ROSData SubElementPose;
-	return DataHelpers::ExtractSubDocument(Message, "pose", SubElementPose) && Pose->FromData(SubElementPose)
-	&& DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
+	return DataHelpers::ExtractSubMessage(Message, "pose", Pose)
+		&& DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
 	{
 		return DataHelpers::ExtractDouble(Array, Key, Result);
 	});

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
@@ -46,9 +46,7 @@ void UROSMsgPoseWithCovariance::SetCovarianceFromFloatArray(const TArray<float> 
 
 void UROSMsgPoseWithCovariance::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementPose;
-	Pose->ToData(SubElementPose);
-	DataHelpers::AppendSubDocument(OutMessage,  "pose", SubElementPose);
+	DataHelpers::AppendSubMessage(OutMessage, "pose", Pose);
 	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 
 	DataHelpers::AppendTArray<double>(OutMessage, "covariance", Covariance, [](ROSData& Array, const char* Key, double TArrayValue)

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
@@ -43,12 +43,7 @@ void UROSMsgPoseWithCovarianceStamped::ToData(ROSData& OutMessage) const
 
 bool UROSMsgPoseWithCovarianceStamped::FromData(const ROSData& Message)
 {
-	if(!Header) Header = NewObject<UROSMsgHeader>(this);
-	if(!Pose) Pose = NewObject<UROSMsgPoseWithCovariance>(this);
-	
-	ROSData SubElementHeader;
-	ROSData SubElementPose;
-	
-	return DataHelpers::ExtractSubDocument(Message,  "header", SubElementHeader) && Header->FromData(SubElementHeader)
-	&& DataHelpers::ExtractSubDocument(Message,  "pose", SubElementPose) && Pose->FromData(SubElementPose);
+	return
+		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
+		DataHelpers::ExtractSubMessage(Message, "pose", Pose);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
@@ -21,13 +21,9 @@ UROSMsgTransformStamped* UROSMsgTransformStamped::CreateEmpty()
 
 void UROSMsgTransformStamped::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementHeader;
-	ROSData SubElementTransform;
-	Header->ToData(SubElementHeader);
-	Transform->ToData(SubElementTransform);
-	DataHelpers::AppendSubDocument(OutMessage,  "header", SubElementHeader);
-	DataHelpers::AppendString(OutMessage,  "child_frame_id", ChildFrameID);
-	DataHelpers::AppendSubDocument(OutMessage,  "transform", SubElementTransform);
+	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
+	DataHelpers::AppendString(OutMessage, "child_frame_id", ChildFrameID);
+	DataHelpers::AppendSubMessage(OutMessage, "transform", Transform);
 }
 
 bool UROSMsgTransformStamped::FromData(const ROSData& Message)

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
@@ -32,12 +32,8 @@ void UROSMsgTransformStamped::ToData(ROSData& OutMessage) const
 
 bool UROSMsgTransformStamped::FromData(const ROSData& Message)
 {
-	if(!Header) Header = NewObject<UROSMsgHeader>(this);
-	if(!Transform) Transform = NewObject<UROSMsgTransform>(this);
-	
-	ROSData SubElementHeader;
-	ROSData SubElementTransform;
-	return DataHelpers::ExtractSubDocument(Message, "header", SubElementHeader) && Header->FromData(SubElementHeader)
-	&& DataHelpers::ExtractString(Message, "child_frame_id", ChildFrameID)
-	&& DataHelpers::ExtractSubDocument(Message, "transform", SubElementTransform) && Transform->FromData(SubElementTransform);
+	return
+		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
+		DataHelpers::ExtractString(Message, "child_frame_id", ChildFrameID) &&
+		DataHelpers::ExtractSubMessage(Message, "transform", Transform);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
@@ -46,9 +46,7 @@ void UROSMsgTwistWithCovariance::SetCovarianceFromFloatArray(const TArray<float>
 
 void UROSMsgTwistWithCovariance::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementTwist;
-	Twist->ToData(SubElementTwist);
-	DataHelpers::AppendSubDocument(OutMessage,  "twist", SubElementTwist);
+	DataHelpers::AppendSubMessage(OutMessage, "twist", Twist);
 	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 
 	DataHelpers::AppendTArray<double>(OutMessage, "covariance", Covariance, [](ROSData& Array, const char* Key, double TArrayValue)

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
@@ -59,12 +59,10 @@ void UROSMsgTwistWithCovariance::ToData(ROSData& OutMessage) const
 
 bool UROSMsgTwistWithCovariance::FromData(const ROSData& Message)
 {
-	if(!Twist) Twist = NewObject<UROSMsgTwist>(this);
-	
-	ROSData SubElementTwist;
-	return DataHelpers::ExtractSubDocument(Message, "twist", SubElementTwist) && Twist->FromData(SubElementTwist)
-	&& DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
-	{
-		return DataHelpers::ExtractDouble(Array, Key, Result);
-	});
+	return
+		DataHelpers::ExtractSubMessage(Message, "twist", Twist) &&
+		DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
+		{
+			return DataHelpers::ExtractDouble(Array, Key, Result);
+		});
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
@@ -38,14 +38,9 @@ void UROSMsgPath::ToData(ROSData& OutMessage) const
 
 bool UROSMsgPath::FromData(const ROSData& Message)
 {
-	if(!Header) Header = NewObject<UROSMsgHeader>(this);
-	Poses = TArray<UROSMsgPoseStamped*>();
-	
-	ROSData SubElementHeader;
-	return DataHelpers::ExtractSubDocument(Message, "header", SubElementHeader) && Header->FromData(SubElementHeader)
+	return DataHelpers::ExtractSubMessage(Message, "header", Header)
 	&& DataHelpers::ExtractTArrayOfUObjects<UROSMsgPoseStamped>(Message, "poses", Poses, this, [](const ROSData& Array, const char* Key, UROSMsgPoseStamped*& Result)
 	{
-		ROSData SubElement;
-		return DataHelpers::ExtractSubDocument(Array, Key, SubElement) && Result->FromData(SubElement);
+		return DataHelpers::ExtractSubMessage(Array, Key, Result);
 	});
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
@@ -24,15 +24,11 @@ void UROSMsgPath::AddPoseInUnrealCoordinateFrame(const FTransform& Transform, UR
 
 void UROSMsgPath::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementHeader;
-	Header->ToData(SubElementHeader);
-	DataHelpers::AppendSubDocument(OutMessage,  "header", SubElementHeader);
+	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
 
 	DataHelpers::AppendTArray<UROSMsgPoseStamped*>(OutMessage, "poses", Poses, [](ROSData& Result, const char* Key, const UROSMsgPoseStamped* TArrayElement)
 	{
-		ROSData SubElement;
-		TArrayElement->ToData(SubElement);
-		DataHelpers::AppendSubDocument(Result,  Key, SubElement);
+		DataHelpers::AppendSubMessage(Result, Key, TArrayElement);
 	});
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
@@ -98,10 +98,8 @@ void UROSMsgCompressedImage::ToData(ROSData& OutMessage) const
 
 bool UROSMsgCompressedImage::FromData(const ROSData& Message)
 {
-	if(!Header) Header = NewObject<UROSMsgHeader>(this);
-	ROSData SubElementHeader;
-
-	return DataHelpers::ExtractSubDocument(Message, "header", SubElementHeader) && Header->FromData(SubElementHeader)
-	    && DataHelpers::ExtractString(Message, "format", Format)
-	    && DataHelpers::ExtractBinary(Message, "data", Data);
+	return
+		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
+		DataHelpers::ExtractString(Message, "format", Format) &&
+		DataHelpers::ExtractBinary(Message, "data", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
@@ -84,10 +84,7 @@ void UROSMsgCompressedImage::ReadData()
 
 void UROSMsgCompressedImage::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementHeader;
-	Header->ToData(SubElementHeader);
-	DataHelpers::AppendSubDocument(OutMessage, "header", SubElementHeader);
-
+	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
 	DataHelpers::AppendString(OutMessage, "format", Format);
 
 	if(ImageWrapper.IsValid()){

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
@@ -31,13 +31,9 @@ void UROSMsgFloat32MultiArray::ToData(ROSData& OutMessage) const
 
 bool UROSMsgFloat32MultiArray::FromData(const ROSData& Message)
 {
-	if(!Layout) Layout = NewObject<UROSMsgMultiArrayLayout>(this);
-
-	ROSData SubElement;
-	
 	return DataHelpers::ExtractTArray<float>(Message, "data", Data, [](const ROSData& Array, const char* Key, float& Result)
 	{
 		return DataHelpers::ExtractFloat(Array, Key, Result);
 	})
-	&& DataHelpers::ExtractSubDocument(Message, "layout", SubElement) && Layout->FromData(SubElement);
+	&& DataHelpers::ExtractSubMessage(Message, "layout", Layout);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
@@ -23,10 +23,7 @@ void UROSMsgFloat32MultiArray::ToData(ROSData& OutMessage) const
 	{
 		DataHelpers::AppendFloat(Array, Key, TArrayValue);
 	});
-
-	ROSData SubElement;
-	Layout->ToData(SubElement);
-	DataHelpers::AppendSubDocument(OutMessage,"layout", SubElement);
+	DataHelpers::AppendSubMessage(OutMessage,"layout", Layout);
 }
 
 bool UROSMsgFloat32MultiArray::FromData(const ROSData& Message)

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
@@ -29,8 +29,7 @@ bool UROSMsgMultiArrayLayout::FromData(const ROSData& Message)
 {
 	return DataHelpers::ExtractTArrayOfUObjects<UROSMsgMultiArrayDimension>(Message, "dim", Dimensions, this, [](const ROSData& Array, const char* Key, UROSMsgMultiArrayDimension*& Result)
 	{
-		ROSData SubElement;
-		return DataHelpers::ExtractSubDocument(Array, Key, SubElement) && Result->FromData(SubElement);
+		return DataHelpers::ExtractSubMessage(Array, Key, Result);
 	})
 	&& DataHelpers::ExtractInt64(Message, "data_offset", DataOffset);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
@@ -18,9 +18,7 @@ void UROSMsgMultiArrayLayout::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::AppendTArray<UROSMsgMultiArrayDimension*>(OutMessage, "dim", Dimensions, [](ROSData& Array, const char* Key, UROSMsgMultiArrayDimension* const& TArrayValue)
 	{
-		ROSData SubElement;
-		TArrayValue->ToData(SubElement);
-		DataHelpers::AppendSubDocument(Array,  Key, SubElement);
+		DataHelpers::AppendSubMessage(Array, Key, TArrayValue);
 	});
 	DataHelpers::AppendUInt32(OutMessage, "data_offset", DataOffset);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
@@ -23,13 +23,9 @@ void UROSMsgUInt8MultiArray::ToData(ROSData& OutMessage) const
 
 bool UROSMsgUInt8MultiArray::FromData(const ROSData& Message)
 {
-	if(!Layout) Layout = NewObject<UROSMsgMultiArrayLayout>(this);
-
-	ROSData SubElement;
-	
 	return DataHelpers::ExtractTArray<uint8>(Message, "data", Data, [](const ROSData& Array, const char* Key, uint8& Result)
 	{
 		return DataHelpers::ExtractUInt8(Array, Key, Result);
 	})
-	&& DataHelpers::ExtractSubDocument(Message, "layout", SubElement) && Layout->FromData(SubElement);
+	&& DataHelpers::ExtractSubMessage(Message, "layout", Layout);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
@@ -15,10 +15,7 @@ void UROSMsgUInt8MultiArray::ToData(ROSData& OutMessage) const
 	{
 		DataHelpers::AppendUInt8(Array, Key, TArrayValue);
 	});
-
-	ROSData SubElement;
-	Layout->ToData(SubElement);
-	DataHelpers::AppendSubDocument(OutMessage,"layout", SubElement);
+	DataHelpers::AppendSubMessage(OutMessage,"layout", Layout);
 }
 
 bool UROSMsgUInt8MultiArray::FromData(const ROSData& Message)

--- a/Source/Rosbridge2Unreal/Public/DataHelpers.h
+++ b/Source/Rosbridge2Unreal/Public/DataHelpers.h
@@ -355,7 +355,7 @@ namespace DataHelpers {
 		}
 	}
 
-	inline void AppendSubMessage(ROSData& OutMessage, const char* Key, UROSMessageBase* Message) {
+	inline void AppendSubMessage(ROSData& OutMessage, const char* Key, const UROSMessageBase* Message) {
 		ROSData Data;
 		Message->ToData(Data);
 		AppendSubDocument(OutMessage, Key, Data);

--- a/Source/Rosbridge2Unreal/Public/DataHelpers.h
+++ b/Source/Rosbridge2Unreal/Public/DataHelpers.h
@@ -334,8 +334,6 @@ namespace DataHelpers {
 
 	template <typename T>
 	inline bool ExtractSubMessage(const ROSData& Message, const char* Key, T*& OutMessageInstance) {
-		check(OutMessageInstance != nullptr);
-
 		if (OutMessageInstance == nullptr)
 		{
 			OutMessageInstance = NewObject<T>();

--- a/Source/Rosbridge2Unreal/Public/DataHelpers.h
+++ b/Source/Rosbridge2Unreal/Public/DataHelpers.h
@@ -331,4 +331,33 @@ namespace DataHelpers {
 
 		Message.insert_or_assign(Key, ArrayNode);
 	}
+
+	template <typename T>
+	inline bool ExtractSubMessage(const ROSData& Message, const char* Key, T** OutMessageInstance) {
+		check(OutMessageInstance != nullptr);
+
+		if (*OutMessageInstance == nullptr)
+		{
+			*OutMessageInstance = NewObject<T>();
+		}
+
+		if (Key[0] == '/')
+		{
+			return (*OutMessageInstance)->FromData(jsoncons::jsonpointer::get(Message, Key));
+		}
+		else if (Message.contains(Key))
+		{
+			return (*OutMessageInstance)->FromData(Message.at(Key));
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	inline void AppendSubMessage(ROSData& OutMessage, const char* Key, UROSMessageBase* Message) {
+		ROSData Data;
+		Message->ToData(Data);
+		AppendSubDocument(OutMessage, Key, Data);
+	}
 }

--- a/Source/Rosbridge2Unreal/Public/DataHelpers.h
+++ b/Source/Rosbridge2Unreal/Public/DataHelpers.h
@@ -333,21 +333,21 @@ namespace DataHelpers {
 	}
 
 	template <typename T>
-	inline bool ExtractSubMessage(const ROSData& Message, const char* Key, T** OutMessageInstance) {
+	inline bool ExtractSubMessage(const ROSData& Message, const char* Key, T*& OutMessageInstance) {
 		check(OutMessageInstance != nullptr);
 
-		if (*OutMessageInstance == nullptr)
+		if (OutMessageInstance == nullptr)
 		{
-			*OutMessageInstance = NewObject<T>();
+			OutMessageInstance = NewObject<T>();
 		}
 
 		if (Key[0] == '/')
 		{
-			return (*OutMessageInstance)->FromData(jsoncons::jsonpointer::get(Message, Key));
+			return OutMessageInstance->FromData(jsoncons::jsonpointer::get(Message, Key));
 		}
 		else if (Message.contains(Key))
 		{
-			return (*OutMessageInstance)->FromData(Message.at(Key));
+			return OutMessageInstance->FromData(Message.at(Key));
 		}
 		else
 		{


### PR DESCRIPTION
Adds ExtractSubMessage and AppendSubMessage to the DataHelpers to simplify (From/To)Data implementations of compound ROS messages. 

**Usage example from IMU message:**

Before
```c++
bool UROSMsgImu::FromData(const ROSData& Message)
{
	if (Header != nullptr) Header = NewObject<UROSMsgHeader>();
	if (Orientation != nullptr) Orientation = NewObject<UROSMsgQuaternion>();
	if (AngularVelocity != nullptr) AngularVelocity = NewObject<UROSMsgVector3>();
	if (LinearAcceleration != nullptr) LinearAcceleration = NewObject<UROSMsgVector3>();

	ROSData SubElementHeader;
	ROSData SubElementOrientation;
	ROSData SubElementAngularVelocity;
	ROSData SubElementLinearAcceleration;
	return
		DataHelpers::ExtractSubDocument(Message, "header", SubElementHeader) && Header->FromData(SubElementHeader) &&
		DataHelpers::ExtractSubDocument(Message, "orientation", SubElementOrientation) && Orientation->FromData(SubElementOrientation) &&
		DataHelpers::ExtractSubDocument(Message, "angular_velocity", SubElementAngularVelocity) && AngularVelocity->FromData(SubElementAngularVelocity) &&
		DataHelpers::ExtractSubDocument(Message, "linear_acceleration", SubElementLinearAcceleration) && LinearAcceleration->FromData(SubElementLinearAcceleration);
}
```
After
```c++
bool UROSMsgImu::FromData(const ROSData& Message)
{
	return 
		DataHelpers::ExtractSubMessage(Message, "header", &Header) &&
		DataHelpers::ExtractSubMessage(Message, "orientation", &Orientation) &&
		DataHelpers::ExtractSubMessage(Message, "angular_velocity", &AngularVelocity) &&
		DataHelpers::ExtractSubMessage(Message, "linear_acceleration", &LinearAcceleration);
}
```
Those two examples should produce the equivalent behavior, except that ExtractSubMessage() does not create an internal copy of the ROSData object.

**Discussion Points**

1. *Naming*: is the term `SubMessage` appropriate?
2. *Parameter type*: The last "output" parameter is a pointer not a reference. This is not consistent with other Extract* functions. However, IMO it is unintuative that `DataHelpers::ExtractSubMessage(Message, "header", Header)` can also thange the destination of the `Header` pointer and not only the data it is pointing to. However, maybe it is better to be consistent with the other functions.
3. *Testing*: `DataHelpers::AppendSubMessage` is not tested yet and it creates an unnecessary copy of the ROSData object.