### PR TITLE
Feature/refactor data helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,12 +277,12 @@ UROSMsgString* UROSMsgString::Create(const FString& Data)
 
 void UROSMsgString::ToData(ROSData& OutMessage) const
 {
-    DataHelpers::AppendString(OutMessage, "data", Data);
+    DataHelpers::Append<FString>(OutMessage, "data", Data);
 }
 
 bool UROSMsgString::FromData(const ROSData& Message)
 {
-    return DataHelpers::ExtractString(Message, "data", Data);
+    return DataHelpers::Extract<FString>(Message, "data", Data);
 }
 ```
 

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoint.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoint.cpp
@@ -31,14 +31,15 @@ void UROSMsgPoint::SetFromFVector(const FVector& InVector)
 
 void UROSMsgPoint::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendDouble(OutMessage, "x", X);
-	DataHelpers::AppendDouble(OutMessage, "y", Y);
-	DataHelpers::AppendDouble(OutMessage, "z", Z);
+	DataHelpers::Append<double>(OutMessage, "x", X);
+	DataHelpers::Append<double>(OutMessage, "y", Y);
+	DataHelpers::Append<double>(OutMessage, "z", Z);
 }
 
 bool UROSMsgPoint::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractDouble(Message, "x", X)
-	&& DataHelpers::ExtractDouble(Message, "y", Y)
-	&& DataHelpers::ExtractDouble(Message, "z", Z);
+	return
+		DataHelpers::Extract<double>(Message, "x", X) &&
+		DataHelpers::Extract<double>(Message, "y", Y) &&
+		DataHelpers::Extract<double>(Message, "z", Z);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPose.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPose.cpp
@@ -63,12 +63,13 @@ void UROSMsgPose::ToData(ROSData& OutMessage) const
 
 bool UROSMsgPose::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<double>(Message, "/position/x", Px)
-	&& DataHelpers::Extract<double>(Message, "/position/y", Py)
-	&& DataHelpers::Extract<double>(Message, "/position/z", Pz)
-	&& DataHelpers::Extract<double>(Message, "/orientation/x", Qx)
-	&& DataHelpers::Extract<double>(Message, "/orientation/y", Qy)
-	&& DataHelpers::Extract<double>(Message, "/orientation/z", Qz)
-	&& DataHelpers::Extract<double>(Message, "/orientation/w", Qw);
+	return
+		DataHelpers::Extract<double>(Message, "/position/x", Px) &&
+		DataHelpers::Extract<double>(Message, "/position/y", Py) &&
+		DataHelpers::Extract<double>(Message, "/position/z", Pz) &&
+		DataHelpers::Extract<double>(Message, "/orientation/x", Qx) &&
+		DataHelpers::Extract<double>(Message, "/orientation/y", Qy) &&
+		DataHelpers::Extract<double>(Message, "/orientation/z", Qz) &&
+		DataHelpers::Extract<double>(Message, "/orientation/w", Qw);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPose.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPose.cpp
@@ -50,25 +50,25 @@ void UROSMsgPose::SetOrientationFromQuad(const FQuat& InOrientation)
 
 void UROSMsgPose::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubDocument(OutMessage, "position", ROSData());
-	DataHelpers::AppendDouble(OutMessage, "/position/x", Px);
-	DataHelpers::AppendDouble(OutMessage, "/position/y", Py);
-	DataHelpers::AppendDouble(OutMessage, "/position/z", Pz);
-	DataHelpers::AppendSubDocument(OutMessage, "orientation", ROSData());
-	DataHelpers::AppendDouble(OutMessage, "/orientation/x", Qx);
-	DataHelpers::AppendDouble(OutMessage, "/orientation/y", Qy);
-	DataHelpers::AppendDouble(OutMessage, "/orientation/z", Qz);
-	DataHelpers::AppendDouble(OutMessage, "/orientation/w", Qw);
+	DataHelpers::Append<ROSData>(OutMessage, "position", ROSData());
+	DataHelpers::Append<double>(OutMessage, "/position/x", Px);
+	DataHelpers::Append<double>(OutMessage, "/position/y", Py);
+	DataHelpers::Append<double>(OutMessage, "/position/z", Pz);
+	DataHelpers::Append<ROSData>(OutMessage, "orientation", ROSData());
+	DataHelpers::Append<double>(OutMessage, "/orientation/x", Qx);
+	DataHelpers::Append<double>(OutMessage, "/orientation/y", Qy);
+	DataHelpers::Append<double>(OutMessage, "/orientation/z", Qz);
+	DataHelpers::Append<double>(OutMessage, "/orientation/w", Qw);
 }
 
 bool UROSMsgPose::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractDouble(Message, "/position/x", Px)
-	&& DataHelpers::ExtractDouble(Message, "/position/y", Py)
-	&& DataHelpers::ExtractDouble(Message, "/position/z", Pz)
-	&& DataHelpers::ExtractDouble(Message, "/orientation/x", Qx)
-	&& DataHelpers::ExtractDouble(Message, "/orientation/y", Qy)
-	&& DataHelpers::ExtractDouble(Message, "/orientation/z", Qz)
-	&& DataHelpers::ExtractDouble(Message, "/orientation/w", Qw);
+	return DataHelpers::Extract<double>(Message, "/position/x", Px)
+	&& DataHelpers::Extract<double>(Message, "/position/y", Py)
+	&& DataHelpers::Extract<double>(Message, "/position/z", Pz)
+	&& DataHelpers::Extract<double>(Message, "/orientation/x", Qx)
+	&& DataHelpers::Extract<double>(Message, "/orientation/y", Qy)
+	&& DataHelpers::Extract<double>(Message, "/orientation/z", Qz)
+	&& DataHelpers::Extract<double>(Message, "/orientation/w", Qw);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
@@ -19,13 +19,13 @@ UROSMsgPoseStamped* UROSMsgPoseStamped::CreateEmpty()
 
 void UROSMsgPoseStamped::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
-	DataHelpers::AppendSubMessage(OutMessage, "pose", Pose);
+	DataHelpers::Append<UROSMsgHeader>(OutMessage, "header", Header);
+	DataHelpers::Append<UROSMsgPose>(OutMessage, "pose", Pose);
 }
 
 bool UROSMsgPoseStamped::FromData(const ROSData& Message)
 {
 	return
-		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
-		DataHelpers::ExtractSubMessage(Message, "pose", Pose);
+		DataHelpers::Extract<UROSMsgHeader>(Message, "header", Header) &&
+		DataHelpers::Extract<UROSMsgPose>(Message, "pose", Pose);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseStamped.cpp
@@ -19,13 +19,13 @@ UROSMsgPoseStamped* UROSMsgPoseStamped::CreateEmpty()
 
 void UROSMsgPoseStamped::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::Append<UROSMsgHeader>(OutMessage, "header", Header);
-	DataHelpers::Append<UROSMsgPose>(OutMessage, "pose", Pose);
+	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);
+	DataHelpers::Append<UROSMsgPose*>(OutMessage, "pose", Pose);
 }
 
 bool UROSMsgPoseStamped::FromData(const ROSData& Message)
 {
 	return
-		DataHelpers::Extract<UROSMsgHeader>(Message, "header", Header) &&
-		DataHelpers::Extract<UROSMsgPose>(Message, "pose", Pose);
+		DataHelpers::Extract<UROSMsgHeader*>(Message, "header", Header) &&
+		DataHelpers::Extract<UROSMsgPose*>(Message, "pose", Pose);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
@@ -51,7 +51,7 @@ void UROSMsgPoseWithCovariance::ToData(ROSData& OutMessage) const
 
 	DataHelpers::AppendTArray<double>(OutMessage, "covariance", Covariance, [](ROSData& Array, const char* Key, double TArrayValue)
 	{
-		DataHelpers::AppendDouble(Array, Key, TArrayValue);
+		DataHelpers::Append<double>(Array, Key, TArrayValue);
 	});
 }
 
@@ -60,6 +60,6 @@ bool UROSMsgPoseWithCovariance::FromData(const ROSData& Message)
 	return DataHelpers::ExtractSubMessage(Message, "pose", Pose)
 		&& DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
 	{
-		return DataHelpers::ExtractDouble(Array, Key, Result);
+		return DataHelpers::Extract<double>(Array, Key, Result);
 	});
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
@@ -46,20 +46,16 @@ void UROSMsgPoseWithCovariance::SetCovarianceFromFloatArray(const TArray<float> 
 
 void UROSMsgPoseWithCovariance::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubMessage(OutMessage, "pose", Pose);
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 
-	DataHelpers::AppendTArray<double>(OutMessage, "covariance", Covariance, [](ROSData& Array, const char* Key, double TArrayValue)
-	{
-		DataHelpers::Append<double>(Array, Key, TArrayValue);
-	});
+	DataHelpers::Append<UROSMsgPose*>(OutMessage, "pose", Pose);
+	DataHelpers::Append<TArray<double>>(OutMessage, "covariance", Covariance);
 }
 
 bool UROSMsgPoseWithCovariance::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractSubMessage(Message, "pose", Pose)
-		&& DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
-	{
-		return DataHelpers::Extract<double>(Array, Key, Result);
-	});
+	return
+		DataHelpers::Extract<UROSMsgPose*>(Message, "pose", Pose) &&
+		DataHelpers::Extract<TArray<double>>(Message, "covariance", Covariance) &&
+		Covariance.Num() == 36;
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovariance.cpp
@@ -7,7 +7,7 @@ UROSMsgPoseWithCovariance* UROSMsgPoseWithCovariance::Create(UROSMsgPose* Pose, 
 	UROSMsgPoseWithCovariance* Message = NewObject<UROSMsgPoseWithCovariance>();
 	Message->Pose = Pose;
 	Message->Covariance = Covariance;
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 	return Message;
 }
 
@@ -16,7 +16,7 @@ UROSMsgPoseWithCovariance* UROSMsgPoseWithCovariance::Create(UROSMsgPose* Pose, 
 	UROSMsgPoseWithCovariance* Message = NewObject<UROSMsgPoseWithCovariance>();
 	Message->Pose = Pose;
 	Message->SetCovarianceFromFloatArray(Covariance);
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 	return Message;
 }
 
@@ -36,9 +36,12 @@ TArray<float> UROSMsgPoseWithCovariance::CovarianceAsFloatArray() const
 	return Result;
 }
 
-void UROSMsgPoseWithCovariance::SetCovarianceFromFloatArray(const TArray<float> InArray)
+void UROSMsgPoseWithCovariance::SetCovarianceFromFloatArray(const TArray<float>& InArray)
 {
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (InArray.Num() != 36)
+	{
+		UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	}
 
 	Covariance.Empty();
 	Covariance.Append(InArray);
@@ -46,7 +49,10 @@ void UROSMsgPoseWithCovariance::SetCovarianceFromFloatArray(const TArray<float> 
 
 void UROSMsgPoseWithCovariance::ToData(ROSData& OutMessage) const
 {
-	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36)
+	{
+		UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	}
 
 	DataHelpers::Append<UROSMsgPose*>(OutMessage, "pose", Pose);
 	DataHelpers::Append<TArray<double>>(OutMessage, "covariance", Covariance);

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
@@ -17,20 +17,6 @@ UROSMsgPoseWithCovarianceStamped* UROSMsgPoseWithCovarianceStamped::CreateEmpty(
 	return Message;
 }
 
-FVector UROSMsgPoseWithCovarianceStamped::GetPositionInUnrealCoordinateFrame() const
-{
-	if(!Pose->IsValidLowLevelFast() || !Pose->Pose->IsValidLowLevelFast()) return FVector();
-	const FVector& Position = Pose->Pose->PositionAsFVector();
-	return FVector(Position.Y, Position.X, Position.Z) * FVector(100,100,100);
-}
-
-FQuat UROSMsgPoseWithCovarianceStamped::GetRotationInUnrealCoordinateFrame() const
-{
-	if(!Pose->IsValidLowLevelFast() || !Pose->Pose->IsValidLowLevelFast()) return FQuat();
-	const FQuat& Rotation = Pose->Pose->OrientationAsQuad();
-	return FQuat(Rotation.Y, -Rotation.X, Rotation.Z, -Rotation.W);
-}
-
 void UROSMsgPoseWithCovarianceStamped::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
@@ -33,17 +33,13 @@ FQuat UROSMsgPoseWithCovarianceStamped::GetRotationInUnrealCoordinateFrame() con
 
 void UROSMsgPoseWithCovarianceStamped::ToData(ROSData& OutMessage) const
 {
-	ROSData SubElementHeader;
-	ROSData SubElementPose;
-	Header->ToData(SubElementHeader);
-	Pose->ToData(SubElementPose);
-	DataHelpers::Append<ROSData>(OutMessage,  "header", SubElementHeader);
-	DataHelpers::Append<ROSData>(OutMessage,  "pose", SubElementPose);
+	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);
+	DataHelpers::Append<UROSMsgPoseWithCovariance*>(OutMessage, "pose", Pose);
 }
 
 bool UROSMsgPoseWithCovarianceStamped::FromData(const ROSData& Message)
 {
 	return
-		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
-		DataHelpers::ExtractSubMessage(Message, "pose", Pose);
+		DataHelpers::Extract<UROSMsgHeader*>(Message, "header", Header) &&
+		DataHelpers::Extract<UROSMsgPoseWithCovariance*>(Message, "pose", Pose);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.cpp
@@ -37,8 +37,8 @@ void UROSMsgPoseWithCovarianceStamped::ToData(ROSData& OutMessage) const
 	ROSData SubElementPose;
 	Header->ToData(SubElementHeader);
 	Pose->ToData(SubElementPose);
-	DataHelpers::AppendSubDocument(OutMessage,  "header", SubElementHeader);
-	DataHelpers::AppendSubDocument(OutMessage,  "pose", SubElementPose);
+	DataHelpers::Append<ROSData>(OutMessage,  "header", SubElementHeader);
+	DataHelpers::Append<ROSData>(OutMessage,  "pose", SubElementPose);
 }
 
 bool UROSMsgPoseWithCovarianceStamped::FromData(const ROSData& Message)

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgQuaternion.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgQuaternion.cpp
@@ -36,9 +36,10 @@ void UROSMsgQuaternion::ToData(ROSData& OutMessage) const
 
 bool UROSMsgQuaternion::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<double>(Message, "x", X)
-	&& DataHelpers::Extract<double>(Message, "y", Y)
-	&& DataHelpers::Extract<double>(Message, "z", Z)
-	&& DataHelpers::Extract<double>(Message, "w", W);
+	return
+		DataHelpers::Extract<double>(Message, "x", X) &&
+		DataHelpers::Extract<double>(Message, "y", Y) &&
+		DataHelpers::Extract<double>(Message, "z", Z) &&
+		DataHelpers::Extract<double>(Message, "w", W);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgQuaternion.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgQuaternion.cpp
@@ -28,17 +28,17 @@ void UROSMsgQuaternion::SetFromFQuat(const FQuat& InQuat)
 
 void UROSMsgQuaternion::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendDouble(OutMessage, "x", X);
-	DataHelpers::AppendDouble(OutMessage, "y", Y);
-	DataHelpers::AppendDouble(OutMessage, "z", Z);
-	DataHelpers::AppendDouble(OutMessage, "z", W);
+	DataHelpers::Append<double>(OutMessage, "x", X);
+	DataHelpers::Append<double>(OutMessage, "y", Y);
+	DataHelpers::Append<double>(OutMessage, "z", Z);
+	DataHelpers::Append<double>(OutMessage, "z", W);
 }
 
 bool UROSMsgQuaternion::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractDouble(Message, "x", X)
-	&& DataHelpers::ExtractDouble(Message, "y", Y)
-	&& DataHelpers::ExtractDouble(Message, "z", Z)
-	&& DataHelpers::ExtractDouble(Message, "w", W);
+	return DataHelpers::Extract<double>(Message, "x", X)
+	&& DataHelpers::Extract<double>(Message, "y", Y)
+	&& DataHelpers::Extract<double>(Message, "z", Z)
+	&& DataHelpers::Extract<double>(Message, "w", W);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransform.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransform.cpp
@@ -78,11 +78,12 @@ void UROSMsgTransform::ToData(ROSData& OutMessage) const
 
 bool UROSMsgTransform::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<double>(Message, "/translation/x", Tx)
-	&& DataHelpers::Extract<double>(Message, "/translation/y", Ty)
-	&& DataHelpers::Extract<double>(Message, "/translation/z", Tz)
-	&& DataHelpers::Extract<double>(Message, "/rotation/x", Rx)
-	&& DataHelpers::Extract<double>(Message, "/rotation/y", Ry)
-	&& DataHelpers::Extract<double>(Message, "/rotation/z", Rz)
-	&& DataHelpers::Extract<double>(Message, "/rotation/w", Rw);
+	return
+		DataHelpers::Extract<double>(Message, "/translation/x", Tx) &&
+		DataHelpers::Extract<double>(Message, "/translation/y", Ty) &&
+		DataHelpers::Extract<double>(Message, "/translation/z", Tz) &&
+		DataHelpers::Extract<double>(Message, "/rotation/x", Rx) &&
+		DataHelpers::Extract<double>(Message, "/rotation/y", Ry) &&
+		DataHelpers::Extract<double>(Message, "/rotation/z", Rz) &&
+		DataHelpers::Extract<double>(Message, "/rotation/w", Rw);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransform.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransform.cpp
@@ -65,24 +65,24 @@ void UROSMsgTransform::SetFromTransform(const FTransform InTransform)
 
 void UROSMsgTransform::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubDocument(OutMessage, "translation", ROSData());
-	DataHelpers::AppendDouble(OutMessage, "/translation/x", Tx);
-	DataHelpers::AppendDouble(OutMessage, "/translation/y", Ty);
-	DataHelpers::AppendDouble(OutMessage, "/translation/z", Tz);
-	DataHelpers::AppendSubDocument(OutMessage, "rotation", ROSData());
-	DataHelpers::AppendDouble(OutMessage, "/rotation/x", Rx);
-	DataHelpers::AppendDouble(OutMessage, "/rotation/y", Ry);
-	DataHelpers::AppendDouble(OutMessage, "/rotation/z", Rz);
-	DataHelpers::AppendDouble(OutMessage, "/rotation/w", Rw);
+	DataHelpers::Append<ROSData>(OutMessage, "translation", ROSData());
+	DataHelpers::Append<double>(OutMessage, "/translation/x", Tx);
+	DataHelpers::Append<double>(OutMessage, "/translation/y", Ty);
+	DataHelpers::Append<double>(OutMessage, "/translation/z", Tz);
+	DataHelpers::Append<ROSData>(OutMessage, "rotation", ROSData());
+	DataHelpers::Append<double>(OutMessage, "/rotation/x", Rx);
+	DataHelpers::Append<double>(OutMessage, "/rotation/y", Ry);
+	DataHelpers::Append<double>(OutMessage, "/rotation/z", Rz);
+	DataHelpers::Append<double>(OutMessage, "/rotation/w", Rw);
 }
 
 bool UROSMsgTransform::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractDouble(Message, "/translation/x", Tx)
-	&& DataHelpers::ExtractDouble(Message, "/translation/y", Ty)
-	&& DataHelpers::ExtractDouble(Message, "/translation/z", Tz)
-	&& DataHelpers::ExtractDouble(Message, "/rotation/x", Rx)
-	&& DataHelpers::ExtractDouble(Message, "/rotation/y", Ry)
-	&& DataHelpers::ExtractDouble(Message, "/rotation/z", Rz)
-	&& DataHelpers::ExtractDouble(Message, "/rotation/w", Rw);
+	return DataHelpers::Extract<double>(Message, "/translation/x", Tx)
+	&& DataHelpers::Extract<double>(Message, "/translation/y", Ty)
+	&& DataHelpers::Extract<double>(Message, "/translation/z", Tz)
+	&& DataHelpers::Extract<double>(Message, "/rotation/x", Rx)
+	&& DataHelpers::Extract<double>(Message, "/rotation/y", Ry)
+	&& DataHelpers::Extract<double>(Message, "/rotation/z", Rz)
+	&& DataHelpers::Extract<double>(Message, "/rotation/w", Rw);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
@@ -21,15 +21,15 @@ UROSMsgTransformStamped* UROSMsgTransformStamped::CreateEmpty()
 
 void UROSMsgTransformStamped::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
+	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);
 	DataHelpers::Append<FString>(OutMessage, "child_frame_id", ChildFrameID);
-	DataHelpers::AppendSubMessage(OutMessage, "transform", Transform);
+	DataHelpers::Append<UROSMsgTransform*>(OutMessage, "transform", Transform);
 }
 
 bool UROSMsgTransformStamped::FromData(const ROSData& Message)
 {
 	return
-		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
+		DataHelpers::Extract<UROSMsgHeader*>(Message, "header", Header) &&
 		DataHelpers::Extract<FString>(Message, "child_frame_id", ChildFrameID) &&
-		DataHelpers::ExtractSubMessage(Message, "transform", Transform);
+		DataHelpers::Extract<UROSMsgTransform*>(Message, "transform", Transform);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTransformStamped.cpp
@@ -22,7 +22,7 @@ UROSMsgTransformStamped* UROSMsgTransformStamped::CreateEmpty()
 void UROSMsgTransformStamped::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
-	DataHelpers::AppendString(OutMessage, "child_frame_id", ChildFrameID);
+	DataHelpers::Append<FString>(OutMessage, "child_frame_id", ChildFrameID);
 	DataHelpers::AppendSubMessage(OutMessage, "transform", Transform);
 }
 
@@ -30,6 +30,6 @@ bool UROSMsgTransformStamped::FromData(const ROSData& Message)
 {
 	return
 		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
-		DataHelpers::ExtractString(Message, "child_frame_id", ChildFrameID) &&
+		DataHelpers::Extract<FString>(Message, "child_frame_id", ChildFrameID) &&
 		DataHelpers::ExtractSubMessage(Message, "transform", Transform);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwist.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwist.cpp
@@ -64,10 +64,11 @@ void UROSMsgTwist::ToData(ROSData& OutMessage) const
 
 bool UROSMsgTwist::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<double>(Message, "/linear/x", LinearX)
-	&& DataHelpers::Extract<double>(Message, "/linear/y", LinearY)
-	&& DataHelpers::Extract<double>(Message, "/linear/z", LinearZ)
-	&& DataHelpers::Extract<double>(Message, "/angular/x", AngularX)
-	&& DataHelpers::Extract<double>(Message, "/angular/y", AngularY)
-	&& DataHelpers::Extract<double>(Message, "/angular/z", AngularZ);
+	return
+		DataHelpers::Extract<double>(Message, "/linear/x", LinearX) &&
+		DataHelpers::Extract<double>(Message, "/linear/y", LinearY) &&
+		DataHelpers::Extract<double>(Message, "/linear/z", LinearZ) &&
+		DataHelpers::Extract<double>(Message, "/angular/x", AngularX) &&
+		DataHelpers::Extract<double>(Message, "/angular/y", AngularY) &&
+		DataHelpers::Extract<double>(Message, "/angular/z", AngularZ);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwist.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwist.cpp
@@ -52,22 +52,22 @@ void UROSMsgTwist::SetAngularFromFVector(const FVector& InVector)
 
 void UROSMsgTwist::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubDocument(OutMessage, "linear", ROSData());
-	DataHelpers::AppendDouble(OutMessage, "/linear/x", LinearX);
-	DataHelpers::AppendDouble(OutMessage, "/linear/y", LinearY);
-	DataHelpers::AppendDouble(OutMessage, "/linear/z", LinearZ);
-	DataHelpers::AppendSubDocument(OutMessage, "angular", ROSData());
-	DataHelpers::AppendDouble(OutMessage, "/angular/x", AngularX);
-	DataHelpers::AppendDouble(OutMessage, "/angular/y", AngularY);
-	DataHelpers::AppendDouble(OutMessage, "/angular/z", AngularZ);
+	DataHelpers::Append<ROSData>(OutMessage, "linear", ROSData());
+	DataHelpers::Append<double>(OutMessage, "/linear/x", LinearX);
+	DataHelpers::Append<double>(OutMessage, "/linear/y", LinearY);
+	DataHelpers::Append<double>(OutMessage, "/linear/z", LinearZ);
+	DataHelpers::Append<ROSData>(OutMessage, "angular", ROSData());
+	DataHelpers::Append<double>(OutMessage, "/angular/x", AngularX);
+	DataHelpers::Append<double>(OutMessage, "/angular/y", AngularY);
+	DataHelpers::Append<double>(OutMessage, "/angular/z", AngularZ);
 }
 
 bool UROSMsgTwist::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractDouble(Message, "/linear/x", LinearX)
-	&& DataHelpers::ExtractDouble(Message, "/linear/y", LinearY)
-	&& DataHelpers::ExtractDouble(Message, "/linear/z", LinearZ)
-	&& DataHelpers::ExtractDouble(Message, "/angular/x", AngularX)
-	&& DataHelpers::ExtractDouble(Message, "/angular/y", AngularY)
-	&& DataHelpers::ExtractDouble(Message, "/angular/z", AngularZ);
+	return DataHelpers::Extract<double>(Message, "/linear/x", LinearX)
+	&& DataHelpers::Extract<double>(Message, "/linear/y", LinearY)
+	&& DataHelpers::Extract<double>(Message, "/linear/z", LinearZ)
+	&& DataHelpers::Extract<double>(Message, "/angular/x", AngularX)
+	&& DataHelpers::Extract<double>(Message, "/angular/y", AngularY)
+	&& DataHelpers::Extract<double>(Message, "/angular/z", AngularZ);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
@@ -46,21 +46,16 @@ void UROSMsgTwistWithCovariance::SetCovarianceFromFloatArray(const TArray<float>
 
 void UROSMsgTwistWithCovariance::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubMessage(OutMessage, "twist", Twist);
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 
-	DataHelpers::AppendTArray<double>(OutMessage, "covariance", Covariance, [](ROSData& Array, const char* Key, double TArrayValue)
-	{
-		DataHelpers::Append<double>(Array, Key, TArrayValue);
-	});
+	DataHelpers::Append<UROSMsgTwist*>(OutMessage, "twist", Twist);
+	DataHelpers::Append<TArray<double>>(OutMessage, "covariance", Covariance);
 }
 
 bool UROSMsgTwistWithCovariance::FromData(const ROSData& Message)
 {
 	return
-		DataHelpers::ExtractSubMessage(Message, "twist", Twist) &&
-		DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
-		{
-			return DataHelpers::Extract<double>(Array, Key, Result);
-		});
+		DataHelpers::Extract<UROSMsgTwist*>(Message, "twist", Twist) &&
+		DataHelpers::Extract<TArray<double>>(Message, "covariance", Covariance) &&
+		Covariance.Num() == 36;
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
@@ -7,7 +7,7 @@ UROSMsgTwistWithCovariance* UROSMsgTwistWithCovariance::Create(UROSMsgTwist* Twi
 	UROSMsgTwistWithCovariance* Message = NewObject<UROSMsgTwistWithCovariance>();
 	Message->Twist = Twist;
 	Message->Covariance = Covariance;
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 	return Message;
 }
 
@@ -16,7 +16,7 @@ UROSMsgTwistWithCovariance* UROSMsgTwistWithCovariance::Create(UROSMsgTwist* Twi
 	UROSMsgTwistWithCovariance* Message = NewObject<UROSMsgTwistWithCovariance>();
 	Message->Twist = Twist;
 	Message->SetCovarianceFromFloatArray(Covariance);
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgTwistWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 	return Message;
 }
 
@@ -38,7 +38,7 @@ TArray<float> UROSMsgTwistWithCovariance::CovarianceAsFloatArray() const
 
 void UROSMsgTwistWithCovariance::SetCovarianceFromFloatArray(const TArray<float>& InArray)
 {
-	if(Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
+	if (Covariance.Num() != 36) UE_LOG(LogROSBridge, Warning, TEXT("Given Covariance Matrix in UROSMsgPoseWithCovariance does not have 36 values, it has %d"), Covariance.Num());
 
 	Covariance.Empty();
 	Covariance.Append(InArray);

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgTwistWithCovariance.cpp
@@ -51,7 +51,7 @@ void UROSMsgTwistWithCovariance::ToData(ROSData& OutMessage) const
 
 	DataHelpers::AppendTArray<double>(OutMessage, "covariance", Covariance, [](ROSData& Array, const char* Key, double TArrayValue)
 	{
-		DataHelpers::AppendDouble(Array, Key, TArrayValue);
+		DataHelpers::Append<double>(Array, Key, TArrayValue);
 	});
 }
 
@@ -61,6 +61,6 @@ bool UROSMsgTwistWithCovariance::FromData(const ROSData& Message)
 		DataHelpers::ExtractSubMessage(Message, "twist", Twist) &&
 		DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
 		{
-			return DataHelpers::ExtractDouble(Array, Key, Result);
+			return DataHelpers::Extract<double>(Array, Key, Result);
 		});
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgVector3.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgVector3.cpp
@@ -38,8 +38,9 @@ void UROSMsgVector3::ToData(ROSData& OutMessage) const
 
 bool UROSMsgVector3::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<double>(Message, "x", X)
-	&& DataHelpers::Extract<double>(Message, "y", Y)
-	&& DataHelpers::Extract<double>(Message, "z", Z);
+	return
+		DataHelpers::Extract<double>(Message, "x", X) &&
+		DataHelpers::Extract<double>(Message, "y", Y) &&
+		DataHelpers::Extract<double>(Message, "z", Z);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgVector3.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/geometry_msgs/ROSMsgVector3.cpp
@@ -31,15 +31,15 @@ void UROSMsgVector3::SetFromFVector(const FVector& InVector)
 
 void UROSMsgVector3::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendDouble(OutMessage, "x", X);
-	DataHelpers::AppendDouble(OutMessage, "y", Y);
-	DataHelpers::AppendDouble(OutMessage, "z", Z);
+	DataHelpers::Append<double>(OutMessage, "x", X);
+	DataHelpers::Append<double>(OutMessage, "y", Y);
+	DataHelpers::Append<double>(OutMessage, "z", Z);
 }
 
 bool UROSMsgVector3::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractDouble(Message, "x", X)
-	&& DataHelpers::ExtractDouble(Message, "y", Y)
-	&& DataHelpers::ExtractDouble(Message, "z", Z);
+	return DataHelpers::Extract<double>(Message, "x", X)
+	&& DataHelpers::Extract<double>(Message, "y", Y)
+	&& DataHelpers::Extract<double>(Message, "z", Z);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/graph_msgs/ROSMsgClock.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/graph_msgs/ROSMsgClock.cpp
@@ -18,6 +18,7 @@ void UROSMsgClock::ToData(ROSData& OutMessage) const
 
 bool UROSMsgClock::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<int32>(Message, "/clock/secs", Seconds)
-	&& DataHelpers::Extract<int32>(Message, "/clock/nsecs", NanoSeconds);
+	return
+		DataHelpers::Extract<int32>(Message, "/clock/secs", Seconds) &&
+		DataHelpers::Extract<int32>(Message, "/clock/nsecs", NanoSeconds);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/graph_msgs/ROSMsgClock.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/graph_msgs/ROSMsgClock.cpp
@@ -11,13 +11,13 @@ UROSMsgClock* UROSMsgClock::Create(int32 InSeconds, int32 InNanoSeconds)
 
 void UROSMsgClock::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubDocument(OutMessage, "clock", ROSData());
-	DataHelpers::AppendInt32(OutMessage, "/clock/secs", Seconds);
-	DataHelpers::AppendInt32(OutMessage, "/clock/nsecs", NanoSeconds);
+	DataHelpers::Append<ROSData>(OutMessage, "clock", ROSData());
+	DataHelpers::Append<int32>(OutMessage, "/clock/secs", Seconds);
+	DataHelpers::Append<int32>(OutMessage, "/clock/nsecs", NanoSeconds);
 }
 
 bool UROSMsgClock::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractInt32(Message, "/clock/secs", Seconds)
-	&& DataHelpers::ExtractInt32(Message, "/clock/nsecs", NanoSeconds);
+	return DataHelpers::Extract<int32>(Message, "/clock/secs", Seconds)
+	&& DataHelpers::Extract<int32>(Message, "/clock/nsecs", NanoSeconds);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSAuthMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSAuthMessage.cpp
@@ -44,7 +44,7 @@ FString UROSAuthMessage::EncodeSHA512(const FString Input)
 	EVP_MD_CTX_destroy(Context);
 
 	FString Result = "";
-	for(uint8 i = 0; i < HashLength; i++)
+	for (uint8 i = 0; i < HashLength; i++)
 	{
 		Result += FString::Printf(TEXT("%02x"), Hash[i]);
 	}

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSAuthMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSAuthMessage.cpp
@@ -16,14 +16,14 @@ void UROSAuthMessage::ToData(ROSData& OutMessage) const
 	const int64 EndTime = FDateTime::UtcNow().ToUnixTimestamp() + 31556952; // Now + 1 Year
 	const FString Mac = EncodeSHA512(FString::Printf(TEXT("%s%s%s%s%lld%s%lld"), *Secret , *Client , *Destination , *Random , Time , *Level , EndTime));
 
-	DataHelpers::AppendString(OutMessage, "op", "auth");
-	DataHelpers::AppendString(OutMessage, "mac", Mac);
-	DataHelpers::AppendString(OutMessage, "client", Client);
-	DataHelpers::AppendString(OutMessage, "dest", Destination);
-	DataHelpers::AppendString(OutMessage, "rand", Random);
-	DataHelpers::AppendInt64(OutMessage, "t", Time);
-	DataHelpers::AppendString(OutMessage, "level", Level);
-	DataHelpers::AppendInt64(OutMessage, "end", EndTime);
+	DataHelpers::Append<FString>(OutMessage, "op", "auth");
+	DataHelpers::Append<FString>(OutMessage, "mac", Mac);
+	DataHelpers::Append<FString>(OutMessage, "client", Client);
+	DataHelpers::Append<FString>(OutMessage, "dest", Destination);
+	DataHelpers::Append<FString>(OutMessage, "rand", Random);
+	DataHelpers::Append<int64>(OutMessage, "t", Time);
+	DataHelpers::Append<FString>(OutMessage, "level", Level);
+	DataHelpers::Append<int64>(OutMessage, "end", EndTime);
 }
 
 bool UROSAuthMessage::FromData(const ROSData& Message)

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceAdvertiseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceAdvertiseMessage.cpp
@@ -3,15 +3,15 @@
 
 void UROSServiceAdvertiseMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "advertise_service");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "service", ServiceName);
-	DataHelpers::AppendString(OutMessage, "type", ServiceType);
+	DataHelpers::Append<FString>(OutMessage, "op", "advertise_service");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "service", ServiceName);
+	DataHelpers::Append<FString>(OutMessage, "type", ServiceType);
 }
 
 bool UROSServiceAdvertiseMessage::FromData(const ROSData& Message)
 {
-	DataHelpers::ExtractString(Message, "id", ID); //optional
-	return DataHelpers::ExtractString(Message, "service", ServiceName)
-	&& DataHelpers::ExtractString(Message, "type", ServiceType);
+	DataHelpers::Extract<FString>(Message, "id", ID); //optional
+	return DataHelpers::Extract<FString>(Message, "service", ServiceName)
+	&& DataHelpers::Extract<FString>(Message, "type", ServiceType);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceAdvertiseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceAdvertiseMessage.cpp
@@ -12,6 +12,7 @@ void UROSServiceAdvertiseMessage::ToData(ROSData& OutMessage) const
 bool UROSServiceAdvertiseMessage::FromData(const ROSData& Message)
 {
 	DataHelpers::Extract<FString>(Message, "id", ID); //optional
-	return DataHelpers::Extract<FString>(Message, "service", ServiceName)
-	&& DataHelpers::Extract<FString>(Message, "type", ServiceType);
+	return
+		DataHelpers::Extract<FString>(Message, "service", ServiceName) &&
+		DataHelpers::Extract<FString>(Message, "type", ServiceType);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceCallMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceCallMessage.cpp
@@ -14,6 +14,6 @@ bool UROSServiceCallMessage::FromData(const ROSData& Message)
 	//optional
 	DataHelpers::Extract<FString>(Message, "id", ID);
 	DataHelpers::Extract<ROSData>(Message, "args", Data);
-	
+
 	return DataHelpers::Extract<FString>(Message, "service", ServiceName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceCallMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceCallMessage.cpp
@@ -3,17 +3,17 @@
 
 void UROSServiceCallMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "call_service");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "service", ServiceName);
-	DataHelpers::AppendSubDocument(OutMessage, "args", Data);
+	DataHelpers::Append<FString>(OutMessage, "op", "call_service");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "service", ServiceName);
+	DataHelpers::Append<ROSData>(OutMessage, "args", Data);
 }
 
 bool UROSServiceCallMessage::FromData(const ROSData& Message)
 {
 	//optional
-	DataHelpers::ExtractString(Message, "id", ID);
-	DataHelpers::ExtractSubDocument(Message, "args", Data);
+	DataHelpers::Extract<FString>(Message, "id", ID);
+	DataHelpers::Extract<ROSData>(Message, "args", Data);
 	
-	return DataHelpers::ExtractString(Message, "service", ServiceName);
+	return DataHelpers::Extract<FString>(Message, "service", ServiceName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceResponseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceResponseMessage.cpp
@@ -3,18 +3,18 @@
 
 void UROSServiceResponseMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "service_response");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "service", ServiceName);
-	DataHelpers::AppendBool(OutMessage, "result", false); /* I got no clue what it does, but it has to be there and false */
-	DataHelpers::AppendSubDocument(OutMessage, "values", Data);
+	DataHelpers::Append<FString>(OutMessage, "op", "service_response");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "service", ServiceName);
+	DataHelpers::Append<bool>(OutMessage, "result", false); /* I got no clue what it does, but it has to be there and false */
+	DataHelpers::Append<ROSData>(OutMessage, "values", Data);
 }
 
 bool UROSServiceResponseMessage::FromData(const ROSData& Message)
 {
 	//optional
-	DataHelpers::ExtractString(Message, "id", ID);
-	DataHelpers::ExtractSubDocument(Message, "values", Data);
+	DataHelpers::Extract<FString>(Message, "id", ID);
+	DataHelpers::Extract<ROSData>(Message, "values", Data);
 	
-	return DataHelpers::ExtractString(Message, "service", ServiceName);
+	return DataHelpers::Extract<FString>(Message, "service", ServiceName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceUnadvertiseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSServiceUnadvertiseMessage.cpp
@@ -3,13 +3,13 @@
 
 void UROSServiceUnadvertiseMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "unadvertise_service");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "service", ServiceName);
+	DataHelpers::Append<FString>(OutMessage, "op", "unadvertise_service");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "service", ServiceName);
 }
 
 bool UROSServiceUnadvertiseMessage::FromData(const ROSData& Message)
 {
-	DataHelpers::ExtractString(Message, "id", ID); //optional
-	return DataHelpers::ExtractString(Message, "service", ServiceName);
+	DataHelpers::Extract<FString>(Message, "id", ID); //optional
+	return DataHelpers::Extract<FString>(Message, "service", ServiceName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicAdvertiseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicAdvertiseMessage.cpp
@@ -3,15 +3,15 @@
 
 void UROSTopicAdvertiseMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "advertise");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "topic", TopicName);
-	DataHelpers::AppendString(OutMessage, "type", MessageType);
+	DataHelpers::Append<FString>(OutMessage, "op", "advertise");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "topic", TopicName);
+	DataHelpers::Append<FString>(OutMessage, "type", MessageType);
 }
 
 bool UROSTopicAdvertiseMessage::FromData(const ROSData& Message)
 {
-	DataHelpers::ExtractString(Message, "id", ID); //optional
-	return DataHelpers::ExtractString(Message, "topic", TopicName)
-	&& DataHelpers::ExtractString(Message, "type", MessageType);
+	DataHelpers::Extract<FString>(Message, "id", ID); //optional
+	return DataHelpers::Extract<FString>(Message, "topic", TopicName)
+	&& DataHelpers::Extract<FString>(Message, "type", MessageType);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicAdvertiseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicAdvertiseMessage.cpp
@@ -12,6 +12,7 @@ void UROSTopicAdvertiseMessage::ToData(ROSData& OutMessage) const
 bool UROSTopicAdvertiseMessage::FromData(const ROSData& Message)
 {
 	DataHelpers::Extract<FString>(Message, "id", ID); //optional
-	return DataHelpers::Extract<FString>(Message, "topic", TopicName)
-	&& DataHelpers::Extract<FString>(Message, "type", MessageType);
+	return
+		DataHelpers::Extract<FString>(Message, "topic", TopicName) &&
+		DataHelpers::Extract<FString>(Message, "type", MessageType);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicPublishMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicPublishMessage.cpp
@@ -3,15 +3,15 @@
 
 void UROSTopicPublishMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "publish");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "topic", TopicName);
-	DataHelpers::AppendSubDocument(OutMessage, "msg", Data);
+	DataHelpers::Append<FString>(OutMessage, "op", "publish");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "topic", TopicName);
+	DataHelpers::Append<ROSData>(OutMessage, "msg", Data);
 }
 
 bool UROSTopicPublishMessage::FromData(const ROSData& Message)
 {
-	DataHelpers::ExtractString(Message, "id", ID); //optional
-	return DataHelpers::ExtractString(Message, "topic", TopicName)
-	&& DataHelpers::ExtractSubDocument(Message, "msg", Data);
+	DataHelpers::Extract<FString>(Message, "id", ID); //optional
+	return DataHelpers::Extract<FString>(Message, "topic", TopicName)
+	&& DataHelpers::Extract<ROSData>(Message, "msg", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicPublishMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicPublishMessage.cpp
@@ -12,6 +12,7 @@ void UROSTopicPublishMessage::ToData(ROSData& OutMessage) const
 bool UROSTopicPublishMessage::FromData(const ROSData& Message)
 {
 	DataHelpers::Extract<FString>(Message, "id", ID); //optional
-	return DataHelpers::Extract<FString>(Message, "topic", TopicName)
-	&& DataHelpers::Extract<ROSData>(Message, "msg", Data);
+	return
+		DataHelpers::Extract<FString>(Message, "topic", TopicName) &&
+		DataHelpers::Extract<ROSData>(Message, "msg", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicSubscribeMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicSubscribeMessage.cpp
@@ -3,23 +3,23 @@
 
 void UROSTopicSubscribeMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "subscribe");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "topic", TopicName);
-	DataHelpers::AppendString(OutMessage, "type", MessageType);
-	DataHelpers::AppendInt32(OutMessage, "throttle_rate", ThrottleRate);
-	DataHelpers::AppendInt32(OutMessage, "queue_length", QueueLength);
-	DataHelpers::AppendString(OutMessage, "compression", Compression);
+	DataHelpers::Append<FString>(OutMessage, "op", "subscribe");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "topic", TopicName);
+	DataHelpers::Append<FString>(OutMessage, "type", MessageType);
+	DataHelpers::Append<int32>(OutMessage, "throttle_rate", ThrottleRate);
+	DataHelpers::Append<int32>(OutMessage, "queue_length", QueueLength);
+	DataHelpers::Append<FString>(OutMessage, "compression", Compression);
 }
 
 bool UROSTopicSubscribeMessage::FromData(const ROSData& Message)
 {
 	//optional
-	DataHelpers::ExtractString(Message, "id", ID);
-	DataHelpers::ExtractString(Message, "type", MessageType);
-	DataHelpers::ExtractInt32(Message, "throttle_rate", ThrottleRate);
-	DataHelpers::ExtractInt32(Message, "queue_length", QueueLength);
-	DataHelpers::ExtractString(Message, "compression", Compression);
+	DataHelpers::Extract<FString>(Message, "id", ID);
+	DataHelpers::Extract<FString>(Message, "type", MessageType);
+	DataHelpers::Extract<int32>(Message, "throttle_rate", ThrottleRate);
+	DataHelpers::Extract<int32>(Message, "queue_length", QueueLength);
+	DataHelpers::Extract<FString>(Message, "compression", Compression);
 	
-	return DataHelpers::ExtractString(Message, "topic", TopicName);
+	return DataHelpers::Extract<FString>(Message, "topic", TopicName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicUnadvertiseMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicUnadvertiseMessage.cpp
@@ -3,13 +3,13 @@
 
 void UROSTopicUnadvertiseMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "unadvertise");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "topic", TopicName);
+	DataHelpers::Append<FString>(OutMessage, "op", "unadvertise");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "topic", TopicName);
 }
 
 bool UROSTopicUnadvertiseMessage::FromData(const ROSData& Message)
 {
-	DataHelpers::ExtractString(Message, "id", ID); //optional
-	return DataHelpers::ExtractString(Message, "topic", TopicName);
+	DataHelpers::Extract<FString>(Message, "id", ID); //optional
+	return DataHelpers::Extract<FString>(Message, "topic", TopicName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicUnsubscribeMessage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/internal/ROSTopicUnsubscribeMessage.cpp
@@ -3,13 +3,13 @@
 
 void UROSTopicUnsubscribeMessage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "op", "unsubscribe");
-	DataHelpers::AppendString(OutMessage, "id", ID);
-	DataHelpers::AppendString(OutMessage, "topic", TopicName);
+	DataHelpers::Append<FString>(OutMessage, "op", "unsubscribe");
+	DataHelpers::Append<FString>(OutMessage, "id", ID);
+	DataHelpers::Append<FString>(OutMessage, "topic", TopicName);
 }
 
 bool UROSTopicUnsubscribeMessage::FromData(const ROSData& Message)
 {
-	DataHelpers::ExtractString(Message, "id", ID); //optional
-	return DataHelpers::ExtractString(Message, "topic", TopicName);
+	DataHelpers::Extract<FString>(Message, "id", ID); //optional
+	return DataHelpers::Extract<FString>(Message, "topic", TopicName);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
@@ -9,19 +9,6 @@ UROSMsgPath* UROSMsgPath::CreateEmpty()
 	return Message;
 }
 
-void UROSMsgPath::AddPoseInUnrealCoordinateFrame(const FTransform& Transform, UROSMsgHeader* HeaderIn)
-{
-	const FQuat& Rotation = Transform.GetRotation();
-	const FVector& Position = Transform.GetTranslation();
-
-	UROSMsgPose* Pose = UROSMsgPose::CreateFromPositionOrientation(
-		FVector(Position.Y, Position.X, Position.Z) / FVector(100, 100, 100),
-		FQuat(Rotation.Y, -Rotation.X, Rotation.Z, -Rotation.W)
-	);
-	
-	Poses.Add(UROSMsgPoseStamped::Create(HeaderIn, Pose));
-}
-
 void UROSMsgPath::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);

--- a/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/nav_msgs/ROSMsgPath.cpp
@@ -24,19 +24,13 @@ void UROSMsgPath::AddPoseInUnrealCoordinateFrame(const FTransform& Transform, UR
 
 void UROSMsgPath::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
-
-	DataHelpers::AppendTArray<UROSMsgPoseStamped*>(OutMessage, "poses", Poses, [](ROSData& Result, const char* Key, const UROSMsgPoseStamped* TArrayElement)
-	{
-		DataHelpers::AppendSubMessage(Result, Key, TArrayElement);
-	});
+	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);
+	DataHelpers::Append<TArray<UROSMsgPoseStamped*>>(OutMessage, "poses", Poses);
 }
 
 bool UROSMsgPath::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractSubMessage(Message, "header", Header)
-	&& DataHelpers::ExtractTArrayOfUObjects<UROSMsgPoseStamped>(Message, "poses", Poses, this, [](const ROSData& Array, const char* Key, UROSMsgPoseStamped*& Result)
-	{
-		return DataHelpers::ExtractSubMessage(Array, Key, Result);
-	});
+	return
+		DataHelpers::Extract<UROSMsgHeader*>(Message, "header", Header) &&
+		DataHelpers::Extract<TArray<UROSMsgPoseStamped*>>(Message, "poses", Poses);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
@@ -84,7 +84,7 @@ void UROSMsgCompressedImage::ReadData()
 
 void UROSMsgCompressedImage::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
+	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);
 	DataHelpers::Append<FString>(OutMessage, "format", Format);
 
 	if(ImageWrapper.IsValid()){
@@ -96,7 +96,7 @@ void UROSMsgCompressedImage::ToData(ROSData& OutMessage) const
 bool UROSMsgCompressedImage::FromData(const ROSData& Message)
 {
 	return
-		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
+		DataHelpers::Extract<UROSMsgHeader*>(Message, "header", Header) &&
 		DataHelpers::Extract<FString>(Message, "format", Format) &&
 		DataHelpers::ExtractBinary(Message, "data", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
@@ -85,7 +85,7 @@ void UROSMsgCompressedImage::ReadData()
 void UROSMsgCompressedImage::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::AppendSubMessage(OutMessage, "header", Header);
-	DataHelpers::AppendString(OutMessage, "format", Format);
+	DataHelpers::Append<FString>(OutMessage, "format", Format);
 
 	if(ImageWrapper.IsValid()){
 		TArray64<uint8> CompressedData = ImageWrapper->GetCompressed(OutputCompressionQuality);
@@ -97,6 +97,6 @@ bool UROSMsgCompressedImage::FromData(const ROSData& Message)
 {
 	return
 		DataHelpers::ExtractSubMessage(Message, "header", Header) &&
-		DataHelpers::ExtractString(Message, "format", Format) &&
+		DataHelpers::Extract<FString>(Message, "format", Format) &&
 		DataHelpers::ExtractBinary(Message, "data", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/sensor_msgs/ROSMsgCompressedImage.cpp
@@ -14,7 +14,7 @@ UROSMsgCompressedImage* UROSMsgCompressedImage::CreateEmpty()
 
 UTexture2D* UROSMsgCompressedImage::CreateFittingTexture()
 {
-	if(!ImageWrapper.IsValid()) ReadData();
+	if (!ImageWrapper.IsValid()) ReadData();
 	
 	UTexture2D* Texture = nullptr;
 
@@ -44,14 +44,15 @@ void UROSMsgCompressedImage::CopyToTexture(UTexture2D* Texture)
 	FUpdateTextureRegion2D* TextureRegion = new FUpdateTextureRegion2D(0, 0, 0, 0, ImageWrapper->GetWidth(), ImageWrapper->GetHeight());
 	TArray64<uint8>* Copy = new TArray64<uint8>(); /* Copy due to Async update needed */
 	Copy->Reserve(ImageWrapper->GetHeight()*ImageWrapper->GetWidth()*OutputChannelNumber);
-	if(ImageWrapper->GetRaw(OutputFormat, OutputBitDepth, *Copy))
+	if (ImageWrapper->GetRaw(OutputFormat, OutputBitDepth, *Copy))
 	{
 		Texture->UpdateTextureRegions(0, 1, TextureRegion, ImageWrapper->GetWidth()*OutputChannelNumber, OutputChannelNumber*OutputBitDepth, Copy->GetData(), [](auto InTextureData, auto InRegions)
 		{
 			delete InTextureData;
 			delete InRegions;
 		});
-	}else
+	}
+	else
 	{
 		delete TextureRegion;
 		delete Copy;
@@ -60,19 +61,21 @@ void UROSMsgCompressedImage::CopyToTexture(UTexture2D* Texture)
 
 FVector2D UROSMsgCompressedImage::GetDimensions()
 {
-	if(!ImageWrapper.IsValid())	return FVector2D(-1,-1);
+	if (!ImageWrapper.IsValid())	return FVector2D(-1,-1);
 	return FVector2D(ImageWrapper->GetWidth(), ImageWrapper->GetHeight());
 }
 
 void UROSMsgCompressedImage::ReadData()
 {
-	if(!ImageWrapper.IsValid()){
+	if (!ImageWrapper.IsValid())
+	{
 		IImageWrapperModule& Module = FModuleManager::LoadModuleChecked<IImageWrapperModule>(FName("ImageWrapper"));
 		const EImageFormat DetectedFormat = Module.DetectImageFormat(Data.GetData(), Data.Num());
-		if(DetectedFormat != EImageFormat::Invalid)
+		if (DetectedFormat != EImageFormat::Invalid)
 		{
 			ImageWrapper = Module.CreateImageWrapper(DetectedFormat);
-		}else
+		}
+		else
 		{
 			UE_LOG(LogROSBridge, Warning, TEXT("ROSMsgCompressedImage with unknown format '%s' found."), *Format);
 			return;
@@ -87,7 +90,8 @@ void UROSMsgCompressedImage::ToData(ROSData& OutMessage) const
 	DataHelpers::Append<UROSMsgHeader*>(OutMessage, "header", Header);
 	DataHelpers::Append<FString>(OutMessage, "format", Format);
 
-	if(ImageWrapper.IsValid()){
+	if (ImageWrapper.IsValid())
+	{
 		TArray64<uint8> CompressedData = ImageWrapper->GetCompressed(OutputCompressionQuality);
 		DataHelpers::AppendBinary(OutMessage, "data", CompressedData.GetData(), CompressedData.Num());
 	}

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32.cpp
@@ -10,10 +10,10 @@ UROSMsgFloat32* UROSMsgFloat32::Create(const float Data)
 
 void UROSMsgFloat32::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendFloat(OutMessage, "data", Data);
+	DataHelpers::Append<float>(OutMessage, "data", Data);
 }
 
 bool UROSMsgFloat32::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractFloat(Message, "data", Data);
+	return DataHelpers::Extract<float>(Message, "data", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
@@ -21,7 +21,7 @@ void UROSMsgFloat32MultiArray::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::AppendTArray<float>(OutMessage, "data", Data, [](ROSData& Array, const char* Key, const float& TArrayValue)
 	{
-		DataHelpers::AppendFloat(Array, Key, TArrayValue);
+		DataHelpers::Append<float>(Array, Key, TArrayValue);
 	});
 	DataHelpers::AppendSubMessage(OutMessage,"layout", Layout);
 }
@@ -30,7 +30,7 @@ bool UROSMsgFloat32MultiArray::FromData(const ROSData& Message)
 {
 	return DataHelpers::ExtractTArray<float>(Message, "data", Data, [](const ROSData& Array, const char* Key, float& Result)
 	{
-		return DataHelpers::ExtractFloat(Array, Key, Result);
+		return DataHelpers::Extract<float>(Array, Key, Result);
 	})
 	&& DataHelpers::ExtractSubMessage(Message, "layout", Layout);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgFloat32MultiArray.cpp
@@ -19,18 +19,13 @@ UROSMsgFloat32MultiArray* UROSMsgFloat32MultiArray::CreateWithEmptyLayout(const 
 
 void UROSMsgFloat32MultiArray::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendTArray<float>(OutMessage, "data", Data, [](ROSData& Array, const char* Key, const float& TArrayValue)
-	{
-		DataHelpers::Append<float>(Array, Key, TArrayValue);
-	});
-	DataHelpers::AppendSubMessage(OutMessage,"layout", Layout);
+	DataHelpers::Append<TArray<float>>(OutMessage, "data", Data);
+	DataHelpers::Append<UROSMsgMultiArrayLayout*>(OutMessage, "layout", Layout);
 }
 
 bool UROSMsgFloat32MultiArray::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractTArray<float>(Message, "data", Data, [](const ROSData& Array, const char* Key, float& Result)
-	{
-		return DataHelpers::Extract<float>(Array, Key, Result);
-	})
-	&& DataHelpers::ExtractSubMessage(Message, "layout", Layout);
+	return
+		DataHelpers::Extract<TArray<float>>(Message, "data", Data) &&
+		DataHelpers::Extract<UROSMsgMultiArrayLayout*>(Message, "layout", Layout);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgHeader.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgHeader.cpp
@@ -28,17 +28,17 @@ UROSMsgHeader* UROSMsgHeader::Create(const FString& FrameID, int64 SequenceID, i
 
 void UROSMsgHeader::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendUInt32(OutMessage, "seq", SequenceID);
-	DataHelpers::AppendSubDocument(OutMessage, "stamp", ROSData());
-	DataHelpers::AppendInt32(OutMessage, "/stamp/secs", Seconds);
-	DataHelpers::AppendInt32(OutMessage, "/stamp/nsecs", NanoSeconds);
-	DataHelpers::AppendString(OutMessage, "frame_id", FrameID);
+	DataHelpers::Append<uint32>(OutMessage, "seq", SequenceID);
+	DataHelpers::Append<ROSData>(OutMessage, "stamp", ROSData());
+	DataHelpers::Append<int32>(OutMessage, "/stamp/secs", Seconds);
+	DataHelpers::Append<int32>(OutMessage, "/stamp/nsecs", NanoSeconds);
+	DataHelpers::Append<FString>(OutMessage, "frame_id", FrameID);
 }
 
 bool UROSMsgHeader::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractInt64(Message, "seq", SequenceID)
-	&& DataHelpers::ExtractString(Message, "frame_id", FrameID)
-	&& DataHelpers::ExtractInt32(Message, "/stamp/secs", Seconds)
-	&& DataHelpers::ExtractInt32(Message, "/stamp/nsecs", NanoSeconds);
+	return DataHelpers::Extract<int64>(Message, "seq", SequenceID)
+	&& DataHelpers::Extract<FString>(Message, "frame_id", FrameID)
+	&& DataHelpers::Extract<int32>(Message, "/stamp/secs", Seconds)
+	&& DataHelpers::Extract<int32>(Message, "/stamp/nsecs", NanoSeconds);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgHeader.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgHeader.cpp
@@ -37,8 +37,9 @@ void UROSMsgHeader::ToData(ROSData& OutMessage) const
 
 bool UROSMsgHeader::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<int64>(Message, "seq", SequenceID)
-	&& DataHelpers::Extract<FString>(Message, "frame_id", FrameID)
-	&& DataHelpers::Extract<int32>(Message, "/stamp/secs", Seconds)
-	&& DataHelpers::Extract<int32>(Message, "/stamp/nsecs", NanoSeconds);
+	return
+		DataHelpers::Extract<int64>(Message, "seq", SequenceID) &&
+		DataHelpers::Extract<FString>(Message, "frame_id", FrameID) &&
+		DataHelpers::Extract<int32>(Message, "/stamp/secs", Seconds) &&
+		DataHelpers::Extract<int32>(Message, "/stamp/nsecs", NanoSeconds);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayDimension.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayDimension.cpp
@@ -13,15 +13,15 @@ UROSMsgMultiArrayDimension* UROSMsgMultiArrayDimension::Create(const FString& La
 
 void UROSMsgMultiArrayDimension::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "label", Label);
-	DataHelpers::AppendUInt32(OutMessage, "size", Size);
-	DataHelpers::AppendUInt32(OutMessage, "stride", Stride);
+	DataHelpers::Append<FString>(OutMessage, "label", Label);
+	DataHelpers::Append<uint32>(OutMessage, "size", Size);
+	DataHelpers::Append<uint32>(OutMessage, "stride", Stride);
 }
 
 bool UROSMsgMultiArrayDimension::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractString(Message, "label", Label)
-	&& DataHelpers::ExtractInt64(Message, "size", Size)
-	&& DataHelpers::ExtractInt64(Message, "stride", Stride);
+	return DataHelpers::Extract<FString>(Message, "label", Label)
+	&& DataHelpers::Extract<int64>(Message, "size", Size)
+	&& DataHelpers::Extract<int64>(Message, "stride", Stride);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayDimension.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayDimension.cpp
@@ -20,8 +20,9 @@ void UROSMsgMultiArrayDimension::ToData(ROSData& OutMessage) const
 
 bool UROSMsgMultiArrayDimension::FromData(const ROSData& Message)
 {
-	return DataHelpers::Extract<FString>(Message, "label", Label)
-	&& DataHelpers::Extract<int64>(Message, "size", Size)
-	&& DataHelpers::Extract<int64>(Message, "stride", Stride);
+	return
+		DataHelpers::Extract<FString>(Message, "label", Label) &&
+		DataHelpers::Extract<int64>(Message, "size", Size) &&
+		DataHelpers::Extract<int64>(Message, "stride", Stride);
 }
 

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
@@ -20,7 +20,7 @@ void UROSMsgMultiArrayLayout::ToData(ROSData& OutMessage) const
 	{
 		DataHelpers::AppendSubMessage(Array, Key, TArrayValue);
 	});
-	DataHelpers::AppendUInt32(OutMessage, "data_offset", DataOffset);
+	DataHelpers::Append<uint32>(OutMessage, "data_offset", DataOffset);
 }
 
 bool UROSMsgMultiArrayLayout::FromData(const ROSData& Message)
@@ -29,5 +29,5 @@ bool UROSMsgMultiArrayLayout::FromData(const ROSData& Message)
 	{
 		return DataHelpers::ExtractSubMessage(Array, Key, Result);
 	})
-	&& DataHelpers::ExtractInt64(Message, "data_offset", DataOffset);
+	&& DataHelpers::Extract<int64>(Message, "data_offset", DataOffset);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgMultiArrayLayout.cpp
@@ -16,18 +16,13 @@ UROSMsgMultiArrayLayout* UROSMsgMultiArrayLayout::Create(const TArray<UROSMsgMul
 
 void UROSMsgMultiArrayLayout::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendTArray<UROSMsgMultiArrayDimension*>(OutMessage, "dim", Dimensions, [](ROSData& Array, const char* Key, UROSMsgMultiArrayDimension* const& TArrayValue)
-	{
-		DataHelpers::AppendSubMessage(Array, Key, TArrayValue);
-	});
+	DataHelpers::Append<TArray<UROSMsgMultiArrayDimension*>>(OutMessage, "dim", Dimensions);
 	DataHelpers::Append<uint32>(OutMessage, "data_offset", DataOffset);
 }
 
 bool UROSMsgMultiArrayLayout::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractTArrayOfUObjects<UROSMsgMultiArrayDimension>(Message, "dim", Dimensions, this, [](const ROSData& Array, const char* Key, UROSMsgMultiArrayDimension*& Result)
-	{
-		return DataHelpers::ExtractSubMessage(Array, Key, Result);
-	})
-	&& DataHelpers::Extract<int64>(Message, "data_offset", DataOffset);
+	return
+		DataHelpers::Extract<TArray<UROSMsgMultiArrayDimension*>>(Message, "dim", Dimensions) &&
+		DataHelpers::Extract<int64>(Message, "data_offset", DataOffset);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgString.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgString.cpp
@@ -10,10 +10,10 @@ UROSMsgString* UROSMsgString::Create(const FString& InData)
 
 void UROSMsgString::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendString(OutMessage, "data", Data);
+	DataHelpers::Append<FString>(OutMessage, "data", Data);
 }
 
 bool UROSMsgString::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractString(Message, "data", Data);
+	return DataHelpers::Extract<FString>(Message, "data", Data);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
@@ -11,18 +11,13 @@ UROSMsgUInt8MultiArray* UROSMsgUInt8MultiArray::Create(const TArray<uint8>& Data
 
 void UROSMsgUInt8MultiArray::ToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendTArray<uint8>(OutMessage, "data", Data, [](ROSData& Array, const char* Key, const uint8& TArrayValue)
-	{
-		DataHelpers::Append<uint8>(Array, Key, TArrayValue);
-	});
-	DataHelpers::AppendSubMessage(OutMessage,"layout", Layout);
+	DataHelpers::Append<TArray<uint8>>(OutMessage, "data", Data);
+	DataHelpers::Append<UROSMsgMultiArrayLayout*>(OutMessage, "layout", Layout);
 }
 
 bool UROSMsgUInt8MultiArray::FromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractTArray<uint8>(Message, "data", Data, [](const ROSData& Array, const char* Key, uint8& Result)
-	{
-		return DataHelpers::Extract<uint8>(Array, Key, Result);
-	})
-	&& DataHelpers::ExtractSubMessage(Message, "layout", Layout);
+	return
+		DataHelpers::Extract<TArray<uint8>>(Message, "data", Data) &&
+		DataHelpers::Extract<UROSMsgMultiArrayLayout*>(Message, "layout", Layout);
 }

--- a/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
+++ b/Source/Rosbridge2Unreal/Private/Messages/std_msgs/ROSMsgUInt8MultiArray.cpp
@@ -13,7 +13,7 @@ void UROSMsgUInt8MultiArray::ToData(ROSData& OutMessage) const
 {
 	DataHelpers::AppendTArray<uint8>(OutMessage, "data", Data, [](ROSData& Array, const char* Key, const uint8& TArrayValue)
 	{
-		DataHelpers::AppendUInt8(Array, Key, TArrayValue);
+		DataHelpers::Append<uint8>(Array, Key, TArrayValue);
 	});
 	DataHelpers::AppendSubMessage(OutMessage,"layout", Layout);
 }
@@ -22,7 +22,7 @@ bool UROSMsgUInt8MultiArray::FromData(const ROSData& Message)
 {
 	return DataHelpers::ExtractTArray<uint8>(Message, "data", Data, [](const ROSData& Array, const char* Key, uint8& Result)
 	{
-		return DataHelpers::ExtractUInt8(Array, Key, Result);
+		return DataHelpers::Extract<uint8>(Array, Key, Result);
 	})
 	&& DataHelpers::ExtractSubMessage(Message, "layout", Layout);
 }

--- a/Source/Rosbridge2Unreal/Private/ROSBridge.cpp
+++ b/Source/Rosbridge2Unreal/Private/ROSBridge.cpp
@@ -228,7 +228,7 @@ void UROSBridge::IncomingMessage(const ROSData& Message)
 	
 	FString OPCode;
 
-	if(!DataHelpers::ExtractString(Message, "op", OPCode)){
+	if(!DataHelpers::Extract<FString>(Message, "op", OPCode)){
 		UE_LOG(LogROSBridge, Warning, TEXT("Received message without op code."));	
 		return;
 	}
@@ -263,7 +263,7 @@ void UROSBridge::IncomingMessage(const ROSData& Message)
 				if(Service->IsAdvertised())
 				{
 					FString Error;
-					DataHelpers::ExtractString(Message, "values", Error);
+					DataHelpers::Extract<FString>(Message, "values", Error);
 					UE_LOG(LogROSBridge, Warning, 
 						TEXT("We received a response to a known service that we have not called. This can be the result of an error in responding to a request. The response is: %s"),
 						*Error

--- a/Source/Rosbridge2Unreal/Private/ROSBridge.cpp
+++ b/Source/Rosbridge2Unreal/Private/ROSBridge.cpp
@@ -16,12 +16,13 @@ bool UROSBridge::Initialize()
 	Settings = GetDefault<URosbridgeSettings>();
 	bSettingsRead = true;
 	
-	if(Settings->bSimulateConnection)
+	if (Settings->bSimulateConnection)
 	{
 		bInitialized = true;
 		return true; //Don't attempt connection
 	}
-	switch(Settings->SocketMode) {
+	switch(Settings->SocketMode)
+	{
 		case ESocketMode::TCP:
 			Connection = NewObject<UTCPConnection>(this);
 			break;
@@ -42,7 +43,7 @@ bool UROSBridge::Initialize()
 
 	bInitialized = true;
 
-	if(Settings->bShouldAuthenticate && ConnectionInitialized)
+	if (Settings->bShouldAuthenticate && ConnectionInitialized)
 	{
 		UROSAuthMessage* AuthMsg = NewObject<UROSAuthMessage>(this);
 		AuthMsg->Client = FString::Printf(TEXT("UnrealClient:%s"),FApp::GetProjectName());
@@ -60,23 +61,24 @@ void UROSBridge::Uninitialize()
 	
 	//Unsubscribe/Unadvertise from everything
 	
-	for(UROSTopic*& Topic : Topics)
+	for (UROSTopic*& Topic : Topics)
 	{
 		Topic->ForceUnsubscribeInternal();
 	}
 	Topics.Empty();
 
-	for(UROSService*& Service : Services)
+	for (UROSService*& Service : Services)
 	{
 		Service->Unadvertise();
 	}
 	Services.Empty();
 	
 	KeepSenderThreadRunning = false;
-	if (SenderThread) {
+	if (SenderThread)
+	{
 		SenderThread->WaitForCompletion();
 	}
-	if(Connection)
+	if (Connection)
 	{
 		Connection->Uninitialize();
 	}
@@ -84,8 +86,8 @@ void UROSBridge::Uninitialize()
 
 bool UROSBridge::SendMessage(const FString& Data) const
 {
-	if(bSettingsRead && Settings->bSimulateConnection) return true;
-	if(!bInitialized) return true; /* return true, since this is no error */
+	if (bSettingsRead && Settings->bSimulateConnection) return true;
+	if (!bInitialized) return true; /* return true, since this is no error */
 	return Connection->SendMessage(Data);
 }
 
@@ -101,12 +103,12 @@ bool UROSBridge::IsBSONMode() const
 
 bool UROSBridge::SendMessage(const UROSBridgeMessage& Message) const
 {
-	if(bSettingsRead && Settings->bSimulateConnection) return true;
-	if(!bInitialized) return true; /* return true, since this is no error */
+	if (bSettingsRead && Settings->bSimulateConnection) return true;
+	if (!bInitialized) return true; /* return true, since this is no error */
 	
 	ROSData Data;
 	Message.ToData(Data);
-	if(Connection->SendMessage(Data))
+	if (Connection->SendMessage(Data))
 	{
 		UE_LOG(LogROSBridge, VeryVerbose, TEXT("Sent ROSBridge message: %s"), *DataHelpers::Internal::DataToString(Data));
 		return true;
@@ -126,7 +128,7 @@ UROSTopic* UROSBridge::GetTopic(const FString& TopicName, TSubclassOf<UROSMessag
 		return Topic->GetTopicName() == TopicName;
 	});
 
-	if(FoundTopic) return *FoundTopic;
+	if (FoundTopic) return *FoundTopic;
 
 	UROSTopic* NewTopic = NewObject<UROSTopic>(this);
 	NewTopic->Initialize(TopicName, MessageClass);
@@ -142,7 +144,7 @@ UROSService* UROSBridge::GetService(const FString& ServiceName, TSubclassOf<UROS
 		return Service->GetServiceName() == ServiceName;
 	});
 
-	if(FoundService) return *FoundService;
+	if (FoundService) return *FoundService;
 
 	UROSService* NewService = NewObject<UROSService>(this);
 	NewService->Initialize(ServiceName, ServiceClass);
@@ -153,26 +155,31 @@ UROSService* UROSBridge::GetService(const FString& ServiceName, TSubclassOf<UROS
 
 void UROSBridge::TickEvent(float DeltaTime)
 {
-	if(!bSettingsRead || !Settings->bEmitClockEvents || !bInitialized) return; //Nothing to do here
+	if (!bSettingsRead || !Settings->bEmitClockEvents || !bInitialized)
+	{
+		//Nothing to do here
+		return;
+	}
 	
-	if(!ClockTopic)
+	if (!ClockTopic)
 	{
 		ClockTopic = GetTopic("/clock", UROSMsgClock::StaticClass());
 		ClockTopic->Advertise();
 	}
 
-	if(!ClockMessage){
+	if (!ClockMessage)
+	{
 		ClockMessage = NewObject<UROSMsgClock>(this);
 	}
 
-	if(!bSetUpdateIntervalSettings)
+	if (!bSetUpdateIntervalSettings)
 	{
 		FApp::SetFixedDeltaTime(Settings->FixedUpdateInterval);
 		FApp::SetUseFixedTimeStep(Settings->bUseFixedUpdateInterval);
 		bSetUpdateIntervalSettings = true;
 	}
 	
-	if(Settings->bUseWallClockTime)
+	if (Settings->bUseWallClockTime)
 	{
 		const FTimespan WallClockTime = FDateTime::UtcNow() - FDateTime::FromUnixTimestamp(0);
 		ClockMessage->Seconds = static_cast<int32>(WallClockTime.GetTotalSeconds()); //Implicit floor
@@ -184,7 +191,8 @@ void UROSBridge::TickEvent(float DeltaTime)
 		const float Fraction = DeltaTime - FMath::FloorToInt(DeltaTime);
 		ClockMessage->Seconds += FMath::FloorToInt(DeltaTime);
 		ClockMessage->NanoSeconds += Fraction * 1000000000ul;
-		if(ClockMessage->NanoSeconds > 1000000000ul){
+		if (ClockMessage->NanoSeconds > 1000000000ul)
+		{
 			ClockMessage->Seconds += 1;
 			ClockMessage->NanoSeconds -= 1000000000ul;
 		}
@@ -194,7 +202,7 @@ void UROSBridge::TickEvent(float DeltaTime)
 
 void UROSBridge::QueueMessage(UROSBridgeMessage* Message)
 {
-	if(!bInitialized) return; //Ignore message that came after closing
+	if (!bInitialized) return; //Ignore message that came after closing
 	
 	MutexMessageQueue.Lock();
 	
@@ -205,9 +213,10 @@ void UROSBridge::QueueMessage(UROSBridgeMessage* Message)
 
 uint32 UROSBridge::Run()
 {
-	while(KeepSenderThreadRunning)
+	while (KeepSenderThreadRunning)
 	{
-		if(QueuedMessages.Num() <= 0){
+		if (QueuedMessages.Num() <= 0)
+		{
 			FPlatformProcess::Sleep(0.01); //Not poll to fast
 			continue;
 		}
@@ -224,23 +233,28 @@ uint32 UROSBridge::Run()
 
 void UROSBridge::IncomingMessage(const ROSData& Message)
 {
-	if(!bInitialized) return; //Ignore message that came after closing
+	if (!bInitialized)
+	{
+		//Ignore message that came after closing
+		return;
+	}
 	
 	FString OPCode;
 
-	if(!DataHelpers::Extract<FString>(Message, "op", OPCode)){
+	if (!DataHelpers::Extract<FString>(Message, "op", OPCode))
+	{
 		UE_LOG(LogROSBridge, Warning, TEXT("Received message without op code."));	
 		return;
 	}
 
-	if(OPCode == "publish") //Message for Topic
+	if (OPCode == "publish") //Message for Topic
 	{
 		UROSTopicPublishMessage* TopicMessage = NewObject<UROSTopicPublishMessage>();
-		if(!TopicMessage->FromData(Message)) return;
+		if (!TopicMessage->FromData(Message)) return;
 		
-		for(UROSTopic* Topic : Topics)
+		for (UROSTopic* Topic : Topics)
 		{
-			if(Topic->GetTopicName() == TopicMessage->TopicName)
+			if (Topic->GetTopicName() == TopicMessage->TopicName)
 			{
 				Topic->IncomingMessage(*TopicMessage);
 				return;
@@ -251,16 +265,16 @@ void UROSBridge::IncomingMessage(const ROSData& Message)
 		return;
 	}
 
-	if(OPCode == "service_response") //Response from service
+	if (OPCode == "service_response") //Response from service
 	{
 		UROSServiceResponseMessage* ServiceMessage = NewObject<UROSServiceResponseMessage>();
-		if(!ServiceMessage->FromData(Message)) return;
+		if (!ServiceMessage->FromData(Message)) return;
 
-		for(UROSService* Service : Services)
+		for (UROSService* Service : Services)
 		{
-			if(Service->GetServiceName() == ServiceMessage->ServiceName)
+			if (Service->GetServiceName() == ServiceMessage->ServiceName)
 			{
-				if(Service->IsAdvertised())
+				if (Service->IsAdvertised())
 				{
 					FString Error;
 					DataHelpers::Extract<FString>(Message, "values", Error);
@@ -280,14 +294,14 @@ void UROSBridge::IncomingMessage(const ROSData& Message)
 		return;
 	}
 
-	if(OPCode == "call_service") //call to a service from us
+	if (OPCode == "call_service") //call to a service from us
 	{
 		UROSServiceCallMessage* ServiceMessage = NewObject<UROSServiceCallMessage>();
-		if(!ServiceMessage->FromData(Message)) return;
+		if (!ServiceMessage->FromData(Message)) return;
 		
-		for(UROSService* Service : Services)
+		for (UROSService* Service : Services)
 		{
-			if(Service->GetServiceName() == ServiceMessage->ServiceName)
+			if (Service->GetServiceName() == ServiceMessage->ServiceName)
 			{
 				Service->IncomingRequest(*ServiceMessage);
 				return;

--- a/Source/Rosbridge2Unreal/Private/ROSService.cpp
+++ b/Source/Rosbridge2Unreal/Private/ROSService.cpp
@@ -11,7 +11,7 @@ void UROSService::Initialize(const FString& ServiceName, TSubclassOf<UROSService
 
 bool UROSService::Advertise(TFunction<void (UROSServiceBase*)> RequestResponseCallback, UROSServiceBase* InReusableRequest)
 {
-	if(bAdvertised) return true; //Already done
+	if (bAdvertised) return true; //Already done
 
 	RequestCallback = RequestResponseCallback;
 	ReusableRequest = InReusableRequest;
@@ -27,7 +27,7 @@ bool UROSService::Advertise(TFunction<void (UROSServiceBase*)> RequestResponseCa
 
 bool UROSService::Unadvertise()
 {
-	if(!bAdvertised) return true; //No need to unadvertise
+	if (!bAdvertised) return true; //No need to unadvertise
 	
 	UROSServiceUnadvertiseMessage* ServiceUnadvertisement = NewObject<UROSServiceUnadvertiseMessage>();
 	ServiceUnadvertisement->ServiceName = StoredServiceName;
@@ -39,7 +39,7 @@ bool UROSService::Unadvertise()
 
 bool UROSService::CallService(const UROSServiceBase* Request, TFunction<void (const UROSServiceBase*)> Callback, UROSServiceBase* InReusableResponse)
 {
-	if(bAdvertised) return false; //Can't call ourselfes
+	if (bAdvertised) return false; //Can't call ourselfes
 
 	UROSServiceCallMessage* ServiceRequest = NewObject<UROSServiceCallMessage>();
 	ServiceRequest->ServiceName = StoredServiceName;
@@ -49,7 +49,7 @@ bool UROSService::CallService(const UROSServiceBase* Request, TFunction<void (co
 	ResponseCallbacks.Add(ServiceRequest->ID, [this, Callback, InReusableResponse](const UROSServiceResponseMessage& Message)
 	{
 		UROSServiceBase* ParsedResponse = InReusableResponse; //either reusable or null
-		if(!ParsedResponse) ParsedResponse = NewObject<UROSServiceBase>(this, *StoredServiceClass);
+		if (!ParsedResponse) ParsedResponse = NewObject<UROSServiceBase>(this, *StoredServiceClass);
 		ParsedResponse->ResponseFromData(Message.Data);
 
 		Callback(ParsedResponse);
@@ -60,7 +60,8 @@ bool UROSService::CallService(const UROSServiceBase* Request, TFunction<void (co
 
 void UROSService::IncomingResponse(const UROSServiceResponseMessage& Message)
 {
-	if(!ResponseCallbacks.Contains(Message.ID)){
+	if (!ResponseCallbacks.Contains(Message.ID))
+	{
 		return; //we have not called
 	}
 	const TFunction<void(const UROSServiceResponseMessage&)> Callback = ResponseCallbacks.FindAndRemoveChecked(Message.ID);
@@ -74,7 +75,7 @@ void UROSService::IncomingRequest(UROSServiceCallMessage& Message)
 	Response->ServiceName = Message.ServiceName;
 	
 	UROSServiceBase* ParsedRequest = ReusableRequest; //either reusable or null
-	if(!ParsedRequest) ParsedRequest = NewObject<UROSServiceBase>(this, *StoredServiceClass);
+	if (!ParsedRequest) ParsedRequest = NewObject<UROSServiceBase>(this, *StoredServiceClass);
 	ParsedRequest->RequestFromData(Message.Data);
 
 	RequestCallback(ParsedRequest);

--- a/Source/Rosbridge2Unreal/Private/ROSServiceHandle.cpp
+++ b/Source/Rosbridge2Unreal/Private/ROSServiceHandle.cpp
@@ -6,7 +6,7 @@
 
 void UROSServiceHandle::Initialize(const FString& ServiceName, TSubclassOf<UROSServiceBase> ServiceClass)
 {
-	if(!ServiceClass)
+	if (!ServiceClass)
 	{
 		UE_LOG(LogROSBridge, Error, TEXT("No class given for initialization of ROSServiceHandle for service %s."), *ServiceName);
 		return;
@@ -16,7 +16,8 @@ void UROSServiceHandle::Initialize(const FString& ServiceName, TSubclassOf<UROSS
 
 void UROSServiceHandle::Advertise(TFunction<void (UROSServiceBase*)> Callback, UROSServiceBase* InReusableRequest)
 {
-	if(!InternalService){
+	if (!InternalService)
+	{
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSServiceHandle before you Advertise to it."));
 		return;
 	}
@@ -36,7 +37,7 @@ void UROSServiceHandle::AdvertiseWithReusableRequest(UROSServiceBase* ReusableRe
 
 void UROSServiceHandle::Unadvertise()
 {
-	if(!InternalService) return;
+	if (!InternalService) return;
 	
 	InternalService->Unadvertise();
 }
@@ -44,7 +45,7 @@ void UROSServiceHandle::Unadvertise()
 
 void UROSServiceHandle::Call(const UROSServiceBase* Request, TFunction<void (const UROSServiceBase*)> Callback, UROSServiceBase* ReusableResponse)
 {
-	if(!InternalService){
+	if (!InternalService){
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSServiceHandle before you can Call it."));
 		return;
 	}
@@ -54,7 +55,7 @@ void UROSServiceHandle::Call(const UROSServiceBase* Request, TFunction<void (con
 
 void UROSServiceHandle::Call(const UROSServiceBase* Request)
 {
-	if(!RecurrentResponseCallback){
+	if (!RecurrentResponseCallback){
 		RegisterResponseCallback([this](const UROSServiceBase* Message){OnResponse.Broadcast(Message);});
 	}
 	CallRecurrent(Request);
@@ -62,7 +63,7 @@ void UROSServiceHandle::Call(const UROSServiceBase* Request)
 
 void UROSServiceHandle::CallWithReusableResponse(const UROSServiceBase* Request, UROSServiceBase* ReusableResponse)
 {
-	if(!RecurrentResponseCallback){
+	if (!RecurrentResponseCallback){
 		RegisterResponseCallback([this](const UROSServiceBase* Message){OnResponse.Broadcast(Message);});
 	}
 	CallRecurrent(Request, ReusableResponse);
@@ -70,7 +71,7 @@ void UROSServiceHandle::CallWithReusableResponse(const UROSServiceBase* Request,
 
 void UROSServiceHandle::CallRecurrent(const UROSServiceBase* Request, UROSServiceBase* ReusableResponse)
 {
-	if(!InternalService){
+	if (!InternalService){
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSServiceHandle before you can Call it."));
 		return;
 	}

--- a/Source/Rosbridge2Unreal/Private/ROSTopic.cpp
+++ b/Source/Rosbridge2Unreal/Private/ROSTopic.cpp
@@ -21,7 +21,8 @@ bool UROSTopic::Subscribe(TFunction<void(const UROSMessageBase* )>& Callback, co
 	StoredCallbacks.Add(UniqueId, Callback);
 	ReusableMessage = InReusableMessage;
 	
-	if(!IsSubscribed){
+	if (!IsSubscribed)
+	{
 		UROSTopicSubscribeMessage* SubscribeMessage = NewObject<UROSTopicSubscribeMessage>();
 		SubscribeMessage->ID = FString::Printf(TEXT("subscribe:%s"), *StoredTopicName);
 		SubscribeMessage->TopicName = StoredTopicName;
@@ -36,7 +37,7 @@ void UROSTopic::Unsubscribe(const uint32 UniqueId)
 {
 	StoredCallbacks.Remove(UniqueId);
 
-	if(IsSubscribed && StoredCallbacks.Num() <= 0)
+	if (IsSubscribed && StoredCallbacks.Num() <= 0)
 	{
 		ForceUnsubscribeInternal();
 	}
@@ -57,12 +58,12 @@ void UROSTopic::IncomingMessage(const UROSTopicPublishMessage& Message)
 {
 	UROSMessageBase* ParsedMessage = ReusableMessage;
 
-	if(!ParsedMessage) //Only generate new, if we don't have a reusable message
+	if (!ParsedMessage) //Only generate new, if we don't have a reusable message
 	{
 		ParsedMessage = NewObject<UROSMessageBase>(this, *StoredMessageClass);
 	}
 	
-	if(!ParsedMessage->FromData(Message.Data))
+	if (!ParsedMessage->FromData(Message.Data))
 	{
 		UE_LOG(LogROSBridge, Warning, TEXT("Error Parsing Message on Topic: %s"), *StoredTopicName);
 		return;
@@ -78,7 +79,7 @@ FString UROSTopic::GetTopicName() const
 
 bool UROSTopic::Advertise()
 {
-	if(!IsAdvertised){
+	if (!IsAdvertised){
 		UROSTopicAdvertiseMessage* AdvertiseMessage = NewObject<UROSTopicAdvertiseMessage>();
 		AdvertiseMessage->ID = FString::Printf(TEXT("advertise:%s"), *StoredTopicName);
 		AdvertiseMessage->TopicName = StoredTopicName;
@@ -92,7 +93,8 @@ bool UROSTopic::Advertise()
 
 bool UROSTopic::Unadvertise()
 {
-	if(IsAdvertised){
+	if (IsAdvertised)
+	{
 		UROSTopicUnadvertiseMessage* UnadvertiseMessage = NewObject<UROSTopicUnadvertiseMessage>();
 		UnadvertiseMessage->ID = FString::Printf(TEXT("advertise:%s"), *StoredTopicName);
 		UnadvertiseMessage->TopicName = StoredTopicName;
@@ -105,7 +107,7 @@ bool UROSTopic::Unadvertise()
 
 void UROSTopic::Publish(const UROSMessageBase* Message)
 {
-	if(!Message)
+	if (!Message)
 	{
 		UE_LOG(LogROSBridge, Warning, TEXT("Tried to publish null message! Ignoring."));
 		return;
@@ -125,7 +127,7 @@ void UROSTopic::Publish(const UROSMessageBase* Message)
 
 void UROSTopic::Notify(UROSMessageBase* Message)
 {
-	for(auto Callback : StoredCallbacks)
+	for (auto Callback : StoredCallbacks)
 	{
 		Callback.Value(Message);
 	}

--- a/Source/Rosbridge2Unreal/Private/ROSTopicHandle.cpp
+++ b/Source/Rosbridge2Unreal/Private/ROSTopicHandle.cpp
@@ -4,7 +4,7 @@
 
 void UROSTopicHandle::Initialize(const FString& TopicName, TSubclassOf<UROSMessageBase> MessageClass)
 {
-	if(!MessageClass)
+	if (!MessageClass)
 	{
 		UE_LOG(LogROSBridge, Error, TEXT("No class given for initialization of ROSTopicHandle for topic %s."), *TopicName);
 		return;
@@ -14,7 +14,8 @@ void UROSTopicHandle::Initialize(const FString& TopicName, TSubclassOf<UROSMessa
 
 void UROSTopicHandle::Subscribe(TFunction<void(const UROSMessageBase*)> Callback, UROSMessageBase* ReusableMessage) const
 {
-	if(!TopicHandle){
+	if (!TopicHandle)
+	{
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSTopicHandle before you Subscribe to it."));
 		return;
 	}
@@ -33,7 +34,8 @@ void UROSTopicHandle::SubscribeWithReusableMessage(UROSMessageBase* ReusableMess
 
 void UROSTopicHandle::Publish(const UROSMessageBase* Message) const
 {
-	if(!TopicHandle){
+	if (!TopicHandle)
+	{
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSTopicHandle before you Publish on it."));
 		return;
 	}
@@ -42,7 +44,8 @@ void UROSTopicHandle::Publish(const UROSMessageBase* Message) const
 
 void UROSTopicHandle::Unsubscribe() const
 {
-	if(!TopicHandle){
+	if (!TopicHandle)
+	{
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSTopicHandle before you Unsubscribe from it."));
 		return;
 	}
@@ -51,7 +54,8 @@ void UROSTopicHandle::Unsubscribe() const
 
 void UROSTopicHandle::Unadvertise() const
 {
-	if(!TopicHandle){
+	if (!TopicHandle)
+	{
 		UE_LOG(LogROSBridge, Warning, TEXT("You first have to initialize your ROSTopicHandle before you Unadvertise it."));
 		return;
 	}

--- a/Source/Rosbridge2Unreal/Private/Rosbridge2Unreal.cpp
+++ b/Source/Rosbridge2Unreal/Private/Rosbridge2Unreal.cpp
@@ -24,7 +24,7 @@ void FRosbridge2UnrealModule::OnSessionEnd(UWorld* World, bool bSessionEnded, bo
 {
 	if (!World->IsGameWorld() || !bSessionEnded) return;
 	
-	if(RosBridge)
+	if (RosBridge)
 	{
 		RosBridge->Uninitialize();
 		RosBridge->RemoveFromRoot(); /* remove the object from the root set to allow garbage collection */
@@ -38,9 +38,9 @@ void FRosbridge2UnrealModule::OnWorldTickStart(UWorld*, ELevelTick TickType, flo
 void FRosbridge2UnrealModule::OnWorldTickStart(ELevelTick TickType, float DeltaTime)
 #endif
 {
-	if(TickType != ELevelTick::LEVELTICK_TimeOnly) return; // Nothing to do here
+	if (TickType != ELevelTick::LEVELTICK_TimeOnly) return; // Nothing to do here
 
-	if(RosBridge) RosBridge->TickEvent(DeltaTime);
+	if (RosBridge) RosBridge->TickEvent(DeltaTime);
 }
 
 bool FRosbridge2UnrealModule::InitializeConnection()
@@ -71,7 +71,7 @@ UROSBridge* FRosbridge2UnrealModule::GetBridge()
 
 bool FRosbridge2UnrealModule::IsBSONMode()
 {
-	if(!RosBridge) return false;
+	if (!RosBridge) return false;
 	return RosBridge->IsBSONMode();
 }
 

--- a/Source/Rosbridge2Unreal/Private/Services/rosapi/ROSSrvTopics.cpp
+++ b/Source/Rosbridge2Unreal/Private/Services/rosapi/ROSSrvTopics.cpp
@@ -17,7 +17,7 @@ void UROSSrvTopics::ResponseToData(ROSData& OutMessage) const
 {
 	DataHelpers::AppendTArray<FString>(OutMessage, "topics", Topics, [](ROSData& Message, const char* Key, const FString& Value)
 	{
-		DataHelpers::AppendString(Message, Key, Value);
+		DataHelpers::Append<FString>(Message, Key, Value);
 	});
 }
 
@@ -25,6 +25,6 @@ bool UROSSrvTopics::ResponseFromData(const ROSData& Message)
 {
 	return DataHelpers::ExtractTArray<FString>(Message, "topics", Topics, [](const ROSData& Message, const char* Key, FString& Value)
 	{
-		return DataHelpers::ExtractString(Message, Key, Value);
+		return DataHelpers::Extract<FString>(Message, Key, Value);
 	});
 }

--- a/Source/Rosbridge2Unreal/Private/Services/rosapi/ROSSrvTopics.cpp
+++ b/Source/Rosbridge2Unreal/Private/Services/rosapi/ROSSrvTopics.cpp
@@ -15,16 +15,10 @@ bool UROSSrvTopics::RequestFromData(const ROSData& Message) {return true;}
 
 void UROSSrvTopics::ResponseToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendTArray<FString>(OutMessage, "topics", Topics, [](ROSData& Message, const char* Key, const FString& Value)
-	{
-		DataHelpers::Append<FString>(Message, Key, Value);
-	});
+	DataHelpers::Append<TArray<FString>>(OutMessage, "topics", Topics);
 }
 
 bool UROSSrvTopics::ResponseFromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractTArray<FString>(Message, "topics", Topics, [](const ROSData& Message, const char* Key, FString& Value)
-	{
-		return DataHelpers::Extract<FString>(Message, Key, Value);
-	});
+	return DataHelpers::Extract<TArray<FString>>(Message, "topics", Topics);
 }

--- a/Source/Rosbridge2Unreal/Private/Services/rospy_tutorials/ROSSrvAddTwoInts.cpp
+++ b/Source/Rosbridge2Unreal/Private/Services/rospy_tutorials/ROSSrvAddTwoInts.cpp
@@ -21,22 +21,22 @@ int UROSSrvAddTwoInts::SumAsInt() const
 
 void UROSSrvAddTwoInts::RequestToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendInt64(OutMessage, "a", A);
-	DataHelpers::AppendInt64(OutMessage, "b", B);
+	DataHelpers::Append<int64>(OutMessage, "a", A);
+	DataHelpers::Append<int64>(OutMessage, "b", B);
 }
 
 bool UROSSrvAddTwoInts::RequestFromData(const ROSData& Message)
 {
-	return	DataHelpers::ExtractInt64(Message, "a", A)
-		&& DataHelpers::ExtractInt64(Message, "b", B);
+	return	DataHelpers::Extract<int64>(Message, "a", A)
+		&& DataHelpers::Extract<int64>(Message, "b", B);
 }
 
 void UROSSrvAddTwoInts::ResponseToData(ROSData& OutMessage) const
 {
-	DataHelpers::AppendInt64(OutMessage, "sum", Sum);
+	DataHelpers::Append<int64>(OutMessage, "sum", Sum);
 }
 
 bool UROSSrvAddTwoInts::ResponseFromData(const ROSData& Message)
 {
-	return DataHelpers::ExtractInt64(Message, "sum", Sum);
+	return DataHelpers::Extract<int64>(Message, "sum", Sum);
 }

--- a/Source/Rosbridge2Unreal/Private/Services/rospy_tutorials/ROSSrvAddTwoInts.cpp
+++ b/Source/Rosbridge2Unreal/Private/Services/rospy_tutorials/ROSSrvAddTwoInts.cpp
@@ -27,8 +27,9 @@ void UROSSrvAddTwoInts::RequestToData(ROSData& OutMessage) const
 
 bool UROSSrvAddTwoInts::RequestFromData(const ROSData& Message)
 {
-	return	DataHelpers::Extract<int64>(Message, "a", A)
-		&& DataHelpers::Extract<int64>(Message, "b", B);
+	return
+		DataHelpers::Extract<int64>(Message, "a", A) &&
+		DataHelpers::Extract<int64>(Message, "b", B);
 }
 
 void UROSSrvAddTwoInts::ResponseToData(ROSData& OutMessage) const

--- a/Source/Rosbridge2Unreal/Private/Socket/NetworkConnection.h
+++ b/Source/Rosbridge2Unreal/Private/Socket/NetworkConnection.h
@@ -19,13 +19,15 @@ public:
 	virtual void Uninitialize() PURE_VIRTUAL(UNetworkConnection::Uninitialize, return;);
 	virtual bool SendMessage(const uint8_t *Data, unsigned int Length) const PURE_VIRTUAL(UNetworkConnection::SendMessage, return true;);
 	
-	bool SendMessage(const ROSData& Data) const {
-		if(CurrentTransportMode == ETransportMode::BSON)
+	bool SendMessage(const ROSData& Data) const
+	{
+		if (CurrentTransportMode == ETransportMode::BSON)
 		{
 			std::vector<uint8> EncodedData;
 			jsoncons::bson::encode_bson(Data,EncodedData);
 			return SendMessage(EncodedData.data(), EncodedData.size());
-		}else if(CurrentTransportMode == ETransportMode::JSON)
+		}
+		else if (CurrentTransportMode == ETransportMode::JSON)
 		{
 			std::string EncodedData;
 			Data.dump(EncodedData, jsoncons::indenting::no_indent);
@@ -34,15 +36,18 @@ public:
 		return false;
 	};
 	
-	bool SendMessage(const FString Data) const {
+	bool SendMessage(const FString Data) const
+	{
 		return SendMessage(reinterpret_cast<const uint8*>(TCHAR_TO_UTF8(*Data)), Data.Len());
 	}
 
-	void RegisterIncomingMessageCallback(TFunction<void(ROSData)> CallbackFunction){
+	void RegisterIncomingMessageCallback(TFunction<void(ROSData)> CallbackFunction)
+	{
 		IncomingMessageCallback = CallbackFunction;
 	}
 	
-	void ReportError(ETransportError Error) const {
+	void ReportError(ETransportError Error) const
+	{
 		switch(Error)
 		{
 		case ETransportError::SocketError:
@@ -54,11 +59,13 @@ public:
 		};
 	};
 
-	void SetTransportMode(ETransportMode Mode){
+	void SetTransportMode(ETransportMode Mode)
+	{
 		CurrentTransportMode = Mode;
 	}
 
-	ETransportMode GetTransportMode() const {
+	ETransportMode GetTransportMode() const
+	{
 		return CurrentTransportMode;
 	};
 };

--- a/Source/Rosbridge2Unreal/Private/Socket/TCPConnection.cpp
+++ b/Source/Rosbridge2Unreal/Private/Socket/TCPConnection.cpp
@@ -9,14 +9,14 @@
 bool UTCPConnection::Initialize(FString IPAddress, int Port, ETransportMode Mode)
 {
 	Socket = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->CreateSocket(NAME_Stream, TEXT("Rosbridge TCP client"), false);
-	
+
 	TSharedRef<FInternetAddr> InternetAddress = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->CreateInternetAddr();
 	bool bIPValid;
 	InternetAddress->SetIp(*IPAddress, bIPValid);
 	InternetAddress->SetPort(Port);
 
 	Socket->SetReceiveBufferSize(65536, ReceiveBufferSize); //16bit address, used by ROSBridge as a default
-	
+
 	if (!bIPValid)
 	{
 		UE_LOG(LogROSBridge, Error, TEXT("Given IP address is invalid: %s"), *IPAddress);
@@ -28,9 +28,9 @@ bool UTCPConnection::Initialize(FString IPAddress, int Port, ETransportMode Mode
 		UE_LOG(LogROSBridge, Error, TEXT("Could not connect to: %s:%d"), *IPAddress, Port);
 		return false;
 	}
-	
+
 	CurrentTransportMode = Mode;
-	
+
 	// Setting up and starting the receiver thread
 	ReceiverThread = FRunnableThread::Create(this, TEXT("ROSBridgeReceiverThread"), 0, TPri_Normal);
 
@@ -40,18 +40,16 @@ bool UTCPConnection::Initialize(FString IPAddress, int Port, ETransportMode Mode
 void UTCPConnection::Uninitialize()
 {
 	bTerminateReceiverThread = true;
-	if (ReceiverThread)
-	{
+	if (ReceiverThread) {
 		ReceiverThread->WaitForCompletion();
 	}
-	if (Socket)
-	{
+	if (Socket) {
 		Socket->Close();
 		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(Socket);
 	}
 }
 
-bool UTCPConnection::SendMessage(const uint8_t *Data, const unsigned int Length) const
+bool UTCPConnection::SendMessage(const uint8_t* Data, const unsigned int Length) const
 {
 	int32 BytesSend = 0;
 	return Socket->Send(Data, Length, BytesSend) && BytesSend == Length;
@@ -61,24 +59,22 @@ bool UTCPConnection::SendMessage(const uint8_t *Data, const unsigned int Length)
 uint32 UTCPConnection::Run()
 {
 	bReceiverThreadRunning = true;
-	
+
 	TArray<uint8> BinaryBuffer;
 	BinaryBuffer.Reserve(ReceiveBufferSize); // at least accomodate the whole socket buffer
 	uint32 PendingData = 0;
 	jsoncons::json_decoder<jsoncons::ojson> Decoder;
 	jsoncons::json_parser Parser;
 
-	while (!bTerminateReceiverThread)
-	{
+	while (!bTerminateReceiverThread) {
 
 		//Check Connection State
 		const ESocketConnectionState ConnectionState = Socket->GetConnectionState();
-		if (ConnectionState == SCS_NotConnected)
-		{
+		if (ConnectionState == SCS_NotConnected) {
 			FPlatformProcess::Sleep(0.5);
 			continue;
 		}
-		else if (ConnectionState == SCS_ConnectionError){
+		else if (ConnectionState == SCS_ConnectionError) {
 			UE_LOG(LogROSBridge, Error, TEXT("Error on connection"));
 			ReportError(ETransportError::SocketError);
 			bReceiverThreadRunning = false;
@@ -90,8 +86,7 @@ uint32 UTCPConnection::Run()
 			continue; // check if any errors occured
 		}
 
-		if
-		(CurrentTransportMode == ETransportMode::BSON){
+		if (CurrentTransportMode == ETransportMode::BSON) {
 			if (!Socket->HasPendingData(PendingData) || PendingData < 4)
 			{
 				continue; //wait further
@@ -108,12 +103,9 @@ uint32 UTCPConnection::Run()
 			}
 
 			//Initialize Buffer
-			if (BinaryBuffer.Num() < BSONMessageLength)
-			{
-				BinaryBuffer.SetNumZeroed(BSONMessageLength, false);
-			}
-			FMemory::Memcpy(BinaryBuffer.GetData(),&BSONMessageLength,sizeof(BSONMessageLength));
-				
+			if (BinaryBuffer.Num() < BSONMessageLength) BinaryBuffer.SetNumZeroed(BSONMessageLength, false);
+			FMemory::Memcpy(BinaryBuffer.GetData(), &BSONMessageLength, sizeof(BSONMessageLength));
+
 			//Receive BSONMessageLength bytes in binary_buffer
 			int32 TotalBytesRead = sizeof(BSONMessageLength);
 			while (TotalBytesRead < BSONMessageLength)
@@ -129,32 +121,27 @@ uint32 UTCPConnection::Run()
 			}
 
 			ROSData Data;
-			try
-			{
+			try {
 				Data = jsoncons::bson::decode_bson<ROSData>(BinaryBuffer.GetData(), BinaryBuffer.GetData() + BSONMessageLength);
 			}
-			catch(jsoncons::ser_error e)
+			catch (jsoncons::ser_error e)
 			{
 				UE_LOG(LogROSBridge, Error, TEXT("Error while parsing BSON message (Ignoring message)"));
 				continue;
 			}
-			
-			if (IncomingMessageCallback && !bTerminateReceiverThread)
-			{
-				IncomingMessageCallback(Data);
-			}
-			
+
+			if (IncomingMessageCallback && !bTerminateReceiverThread) IncomingMessageCallback(Data);
+
 		}
-		else if (CurrentTransportMode == ETransportMode::JSON)
-		{
+		else if (CurrentTransportMode == ETransportMode::JSON) {
 
 			if (!Socket->HasPendingData(PendingData)) continue;
-			
+
 			//Ensure space in buffer
-			if(static_cast<uint32>(BinaryBuffer.Num()) < PendingData) BinaryBuffer.SetNumUninitialized(PendingData, false);
-			
+			if (static_cast<uint32>(BinaryBuffer.Num()) < PendingData) BinaryBuffer.SetNumUninitialized(PendingData, false);
+
 			int32 BytesRead = 0;
-			if(!Socket->Recv(BinaryBuffer.GetData(), PendingData, BytesRead))
+			if (!Socket->Recv(BinaryBuffer.GetData(), PendingData, BytesRead))
 			{
 				UE_LOG(LogROSBridge, Error, TEXT("Failed to receive from socket. Closing receiver thread."));
 				ReportError(ETransportError::SocketError);
@@ -164,22 +151,28 @@ uint32 UTCPConnection::Run()
 
 			if (BytesRead <= 0) continue;
 
-			try{
+			try {
 				Parser.update(reinterpret_cast<char*>(BinaryBuffer.GetData()), BytesRead);
 				do
 				{
 					Parser.parse_some(Decoder);
-					
-					if(Parser.done())
+
+					if (Parser.done())
 					{
 						ROSData Data = Decoder.get_result();
 						if (IncomingMessageCallback && !bTerminateReceiverThread) IncomingMessageCallback(Data);
 						Parser.reset();
 					}
-				} while(!Parser.source_exhausted());
-			}catch(jsoncons::ser_error e)
+				} while (!Parser.source_exhausted());
+			}
+			catch (jsoncons::ser_error e)
 			{
 				UE_LOG(LogROSBridge, Fatal, TEXT("Error while parsing JSON message: %hs"), e.what());
 				throw;
 			}
 		}
+	}
+
+	bReceiverThreadRunning = false;
+	return EXIT_SUCCESS;
+}

--- a/Source/Rosbridge2Unreal/Private/Socket/TCPConnection.h
+++ b/Source/Rosbridge2Unreal/Private/Socket/TCPConnection.h
@@ -12,14 +12,14 @@
 UCLASS()
 class ROSBRIDGE2UNREAL_API UTCPConnection : public UNetworkConnection, public FRunnable {
 	GENERATED_BODY()
-	
+
 public:
 	bool Initialize(FString IPAddress, int Port, ETransportMode Mode) override;
 	void Uninitialize() override;
-	bool SendMessage(const uint8_t *Data, unsigned int Length) const override;
+	bool SendMessage(const uint8_t* Data, unsigned int Length) const override;
 
 private:
-	FSocket *Socket = nullptr;
+	FSocket* Socket = nullptr;
 	int32 ReceiveBufferSize = -1;
 
 	FRunnableThread* ReceiverThread = nullptr;

--- a/Source/Rosbridge2Unreal/Public/DataHelpers.h
+++ b/Source/Rosbridge2Unreal/Public/DataHelpers.h
@@ -1,25 +1,29 @@
 #pragma once
 
+#include <type_traits> // For is_base_of, unreal does not seem to have an equivalent
 #include "CoreMinimal.h"
 #include "TypeDefinitions.h"
 
-namespace DataHelpers {
+namespace DataHelpers
+{
 
-/* Misc Types */
+	/* Misc Types */
 
 	namespace Internal
 	{
-		template<typename JSONType, typename UnrealType>
-		bool Extract(const ROSData& Message, const char* Key, UnrealType& OutData){
-			if(Key[0] == '/')
+		template <typename JSONType, typename UnrealType>
+		bool Extract(const ROSData &Message, const char *Key, UnrealType &OutData)
+		{
+			if (Key[0] == '/')
 			{
 				ROSData Element = jsoncons::jsonpointer::get(Message, Key);
-				if(!Element.is<JSONType>()) return false;
+				if (!Element.is<JSONType>())
+					return false;
 				OutData = static_cast<UnrealType>(Element.as<JSONType>());
 				return true;
 			}
 
-			if(Message.contains(Key) && Message[Key].is<JSONType>())
+			if (Message.contains(Key) && Message[Key].is<JSONType>())
 			{
 				OutData = static_cast<UnrealType>(Message[Key].as<JSONType>());
 				return true;
@@ -27,315 +31,114 @@ namespace DataHelpers {
 			return false;
 		}
 
-		template<typename JSONType, typename UnrealType>
-		bool Append(ROSData& Message, const char* Key, const UnrealType& InData){
-			if(Key[0] == '/')
+		template <typename JSONType, typename UnrealType>
+		bool Append(ROSData &Message, const char *Key, const UnrealType &InData)
+		{
+			if (Key[0] == '/')
 			{
 				jsoncons::jsonpointer::insert_or_assign(Message, Key, ROSData(static_cast<JSONType>(InData)));
 			}
 			else
 			{
-				Message.insert_or_assign(Key,static_cast<JSONType>(InData));
+				Message.insert_or_assign(Key, static_cast<JSONType>(InData));
 			}
 			return false;
 		}
 
-		static bool DecodeBinary(const ROSData& Message, TArray<uint8>& OutData)
+		static bool DecodeBinary(const ROSData &Message, TArray<uint8> &OutData)
 		{
-			if(Message.is_byte_string_view()) /* Real byte string in BSON */
+			if (Message.is_byte_string_view()) /* Real byte string in BSON */
 			{
 				const jsoncons::byte_string_view Bytes = Message.as_byte_string_view();
 				OutData.SetNumUninitialized(Bytes.size());
 				FMemory::Memcpy(OutData.GetData(), Bytes.data(), Bytes.size());
 				return true;
-			}else if(Message.is_string_view()){ /* Binary in Base64 is decoded as string in JSON */
+			}
+			else if (Message.is_string_view())
+			{ /* Binary in Base64 is decoded as string in JSON */
 				const jsoncons::string_view Bytes = Message.as_string_view();
-				OutData.SetNumUninitialized(FBase64::GetDecodedDataSize(Bytes.data(),Bytes.length()));
+				OutData.SetNumUninitialized(FBase64::GetDecodedDataSize(Bytes.data(), Bytes.length()));
 				return FBase64::Decode(Bytes.data(), Bytes.length(), OutData.GetData());
 			}
 			return false;
 		}
-		
+
 		/* Just for debugging purposes */
-		static FString DataToString(const ROSData& Document)
+		static FString DataToString(const ROSData &Document)
 		{
 			std::string S;
 			Document.dump(S, jsoncons::indenting::indent);
 			return UTF8_TO_TCHAR(S.c_str());
 		}
 	}
-	
-	
-	static void AppendSubDocument(ROSData& Message, const char* Key, const ROSData& SubDocument)
-	{
-		if(Key[0] == '/')
-		{
-			jsoncons::jsonpointer::insert_or_assign(Message, Key, SubDocument);
-		}
-		else
-		{
-			Message.insert_or_assign(Key,SubDocument);
-		}
-	}
 
-	static bool ExtractSubDocument(const ROSData& Message, const char* Key, ROSData& OutDocument)
-	{
-		if(Key[0] == '/')
-		{
-			OutDocument = jsoncons::jsonpointer::get(Message, Key);
-			return true;
-		}
-		else if(Message.contains(Key))
-		{
-			OutDocument = Message.at(Key);
-			return true;
-		}
-		
-		return false;
-	}
-	
-	static bool ExtractString(const ROSData& Message, const char* Key, FString& OutData)
-	{
-		if(Key[0] == '/')
-		{
-			const ROSData Element = jsoncons::jsonpointer::get(Message, Key);
-			if(!Element.is_string()) return false;
-			OutData = UTF8_TO_TCHAR(Element.as_cstring());
-			return true;
-		}
-		
-		if(Message.contains(Key) && Message[Key].is_string())
-		{
-			OutData = UTF8_TO_TCHAR(Message[Key].as_cstring());
-			return true;
-		}
-		return false;
-	}
-
-	static void AppendString(ROSData& Message, const char* Key, const FString& InData)
-	{
-		if(Key[0] == '/')
-		{
-			jsoncons::jsonpointer::insert_or_assign(Message, Key, ROSData());
-		}
-		else
-		{
-			Message.insert_or_assign(Key,TCHAR_TO_UTF8(*InData));
-		}
-	}
-
-	static bool ExtractBool(const ROSData& Message, const char* Key, bool& OutData)
-	{
-		return Internal::Extract<bool, bool>(Message, Key, OutData);
-	}
-
-	static void AppendBool(ROSData& Message, const char* Key, const bool& InData)
-	{
-		Internal::Append<bool>(Message, Key, InData);
-	}
-
-	static bool ExtractBinary(const ROSData& Message, const char* Key, TArray<uint8>& OutData)
-	{
-		if(Key[0] == '/')
-		{
-			return Internal::DecodeBinary(jsoncons::jsonpointer::get(Message, Key), OutData);
-		}
-		
-		if(Message.contains(Key))
-		{
-			return Internal::DecodeBinary(Message[Key], OutData);;
-		}
-		return false;
-	}
-
-	static void AppendBinary(ROSData& Message, const char* Key, const uint8* InData, const uint32 DataLength)
-	{
-		const ROSData Data = ROSData(jsoncons::byte_string_arg, std::vector<uint8_t>(InData, InData+DataLength), jsoncons::semantic_tag::base64);
-
-		if(Key[0] == '/')
-		{
-			jsoncons::jsonpointer::insert_or_assign(Message, Key, Data);
-		}
-		else
-		{
-			Message.insert_or_assign(Key,Data);
-		}
-	}
-
-/* All Number Types */
-
-	/* Floating Point */
-
-		static bool ExtractDouble(const ROSData& Message, const char* Key, double& OutData)
-		{
-			return Internal::Extract<double, double>(Message, Key, OutData);
-		}
-
-		static void AppendDouble(ROSData& Message, const char* Key, double InData)
-		{
-			Internal::Append<double>(Message, Key, InData);
-		}
-
-		/* Floats are internally encoded as double by ROSBridge */
-		static bool ExtractFloat(const ROSData& Message, const char* Key, float& OutData)
-		{
-			return Internal::Extract<double, float>(Message, Key, OutData);
-		}
-	
-		/* Floats are internally encoded as double by ROSBridge */
-		static void AppendFloat(ROSData& Message, const char* Key, const float& InData)
-		{
-			Internal::Append<double>(Message, Key, InData);
-		}
-
-	/* Signed Integer */
-	
-		static bool ExtractInt64(const ROSData& Message, const char* Key, int64& OutData)
-		{
-			return Internal::Extract<int64_t, int64>(Message, Key, OutData);
-		}
-
-		static void AppendInt64(ROSData& Message, const char* Key, const int64& InData)
-		{
-			Internal::Append<int64_t>(Message, Key, InData);
-		}
-
-		static bool ExtractInt32(const ROSData& Message, const char* Key, int32& OutData)
-		{
-			return Internal::Extract<int32_t, int32>(Message, Key, OutData);
-		}
-
-		static void AppendInt32(ROSData& Message, const char* Key, const int32& InData)
-		{
-			Internal::Append<int32_t>(Message, Key, InData);
-		}
-
-		static bool ExtractInt16(const ROSData& Message, const char* Key, int16& OutData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. int16 -> int32
-			return Internal::Extract<int32_t, int16>(Message, Key, OutData);
-		}
-
-		static void AppendInt16(ROSData& Message, const char* Key, const int16& InData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. int16 -> int32
-			Internal::Append<int32_t>(Message, Key, InData);
-		}
-
-		static bool ExtractInt8(const ROSData& Message, const char* Key, int8& OutData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. int8 -> uint32
-			return Internal::Extract<int32_t, int8>(Message, Key, OutData);
-		}
-
-		static void AppendInt8(ROSData& Message, const char* Key, const int8& InData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. int8 -> int32
-			Internal::Append<int32_t>(Message, Key, InData);
-		}
-
-	/* Unsigned Integer */
-
-		static bool ExtractUInt64(const ROSData& Message, const char* Key, uint64& OutData)
-		{
-			return Internal::Extract<uint64_t, uint64>(Message, Key, OutData);
-		}
-
-		static void AppendUInt64(ROSData& Message, const char* Key, const uint64& InData)
-		{
-			Internal::Append<uint64_t>(Message, Key, InData);
-		}
-
-		static bool ExtractUInt32(const ROSData& Message, const char* Key, uint32& OutData)
-		{	
-			return Internal::Extract<uint32_t, uint32>(Message, Key, OutData);
-		}
-
-		static void AppendUInt32(ROSData& Message, const char* Key, const uint32& InData)
-		{
-			Internal::Append<uint32_t>(Message, Key, InData);
-		}
-
-		static bool ExtractUInt16(const ROSData& Message, const char* Key, uint16& OutData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. uint8 -> uint32
-			return Internal::Extract<uint32_t, uint16>(Message, Key, OutData);
-		}
-
-		static void AppendUInt16(ROSData& Message, const char* Key, const uint16& InData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. uint16 -> uint32
-			Internal::Append<uint32_t>(Message, Key, InData);
-		}
-
-		static bool ExtractUInt8(const ROSData& Message, const char* Key, uint8& OutData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. uint8 -> uint32
-			return Internal::Extract<uint32_t, uint8>(Message, Key, OutData);
-		}
-
-		static void AppendUInt8(ROSData& Message, const char* Key, const uint8& InData)
-		{
-			//ROSBridge encodes smaller types in known bigger types. uint8 -> uint32
-			Internal::Append<uint32_t>(Message, Key, InData);
-		}
-	
-/* Arrays */
-
-	template<typename T>
-	static bool ExtractTArrayOfUObjects(const ROSData& Message, const char* Key, TArray<T*>& Array, UObject* ParentObject, const TFunction<bool(const ROSData&, const char*, T*&)>& ExtractElement)
-	{
-		if(!Message.contains(Key) || !Message[Key].is_array()) return false;
-
-		Array.SetNum(Message[Key].size());
-		
-		for (uint64 i = 0; i < Message[Key].size(); i++) {
-			T* Temp = NewObject<T>(ParentObject); //Needs to be used for UObject
-			if (ExtractElement(Message[Key], ("/" + std::to_string(i)).c_str(), Temp)){
-				Array[i] = MoveTempIfPossible(Temp);
-			} else {
-				return false;
-			}
-		}
-		return true;
-	}
-	
-	template<typename T>
-	static bool ExtractTArray(const ROSData& Message, const char* Key, TArray<T>& Array, const TFunction<bool(const ROSData&, const char*, T&)>& ExtractElement)
-	{
-		if(!Message.contains(Key) || !Message[Key].is_array()) return false;
-
-		Array.SetNum(Message[Key].size());
-		
-		for (uint64 i = 0; i < Message[Key].size(); i++) {
-			T Temp;
-			if (ExtractElement(Message[Key], ("/" + std::to_string(i)).c_str(), Temp)){
-				Array[i] = MoveTempIfPossible(Temp);
-			} else {
-				return false;
-			}
-		}
-		return true;
-	}
-	
-	template<typename T>
-	static void AppendTArray(ROSData& Message, const char* Key, const TArray<T>& Array, const TFunction<void(ROSData&, const char*, const T&)>& AppendElement)
-	{
-		ROSData ArrayNode = ROSData(jsoncons::json_array_arg);
-		ArrayNode.reserve(Array.Num());
-		
-		for(int i = 0; i < Array.Num(); i++)
-		{
-			AppendElement(ArrayNode, ("/" + std::to_string(i)).c_str(), Array[i]);
-		}
-
-		Message.insert_or_assign(Key, ArrayNode);
+#define DEFINE_SIMPLE_DATA_TYPE(InternalType, UnrealType)                                          \
+	template <>                                                                                    \
+	inline void Append<UnrealType>(ROSData & OutMessage, const char *Key, const UnrealType &Value) \
+	{                                                                                              \
+		Internal::Append<UnrealType>(OutMessage, Key, Value);                                      \
+	}                                                                                              \
+	template <>                                                                                    \
+	inline bool Extract<UnrealType>(const ROSData &Message, const char *Key, UnrealType &OutValue) \
+	{                                                                                              \
+		return Internal::Extract<UnrealType>(Message, Key, OutValue);                              \
 	}
 
 	template <typename T>
-	inline bool ExtractSubMessage(const ROSData& Message, const char* Key, T*& OutMessageInstance) {
-		check(OutMessageInstance != nullptr);
+	inline void Append(ROSData &OutMessage, const char *Key, const T &Value);
 
+	template <typename T>
+	inline bool Extract(const ROSData &Message, const char *Key, T &OutValue);
+
+	DEFINE_SIMPLE_DATA_TYPE(int64, int64)
+	DEFINE_SIMPLE_DATA_TYPE(int32, int32)
+	DEFINE_SIMPLE_DATA_TYPE(int32, int16)
+	DEFINE_SIMPLE_DATA_TYPE(int32, int8)
+
+	DEFINE_SIMPLE_DATA_TYPE(uint64, uint64)
+	DEFINE_SIMPLE_DATA_TYPE(uint32, uint32)
+	DEFINE_SIMPLE_DATA_TYPE(uint32, uint16)
+	DEFINE_SIMPLE_DATA_TYPE(uint32, uint8)
+
+	DEFINE_SIMPLE_DATA_TYPE(double, double)
+	DEFINE_SIMPLE_DATA_TYPE(double, float)
+
+	DEFINE_SIMPLE_DATA_TYPE(bool, bool)
+
+	DEFINE_SIMPLE_DATA_TYPE(ROSData, ROSData)
+
+	template <>
+	inline void Append<FString>(ROSData &OutMessage, const char *Key, const FString &Value)
+	{
+		Internal::Append<const char *>(OutMessage, Key, TCHAR_TO_UTF8(*Value));
+	}
+
+	template <>
+	inline bool Extract<FString>(const ROSData &Message, const char *Key, FString &OutValue)
+	{
+		const char *CString;
+		if (Internal::Extract<const char *>(Message, Key, CString))
+		{
+			OutValue = UTF8_TO_TCHAR(CString);
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	template <typename T>
+	inline typename TEnableIf<std::is_base_of<UROSMessageBase, T>::value, void>::Type Append(ROSData &OutMessage, const char *Key, const T *Message)
+	{
+		ROSData Data;
+		Message->ToData(Data);
+		Append<ROSData>(OutMessage, Key, Data);
+	}
+
+	template <typename T>
+	inline typename TEnableIf<std::is_base_of<UROSMessageBase, T>::value, bool>::Type Extract(const ROSData &Message, const char *Key, T *&OutMessageInstance)
+	{
 		if (OutMessageInstance == nullptr)
 		{
 			OutMessageInstance = NewObject<T>();
@@ -355,9 +158,95 @@ namespace DataHelpers {
 		}
 	}
 
-	inline void AppendSubMessage(ROSData& OutMessage, const char* Key, const UROSMessageBase* Message) {
-		ROSData Data;
-		Message->ToData(Data);
-		AppendSubDocument(OutMessage, Key, Data);
+	template <typename T>
+	inline void Append(ROSData &OutMessage, const char *Key, const TArray<T>& Array)
+	{
+		ROSData ArrayData = ROSData(jsoncons::json_array_arg);
+		ArrayData.reserve(Array.Num());
+
+		for (const auto& Value : Array)
+		{
+			const std::string path = "/" + std::to_string(ArrayData.size());
+			Append(ArrayData, Key, Value);
+		}
+
+		OutMessage.insert_or_assign(Key, ArrayData);
+	}
+
+	static bool ExtractBinary(const ROSData &Message, const char *Key, TArray<uint8> &OutData)
+	{
+		if (Key[0] == '/')
+		{
+			return Internal::DecodeBinary(jsoncons::jsonpointer::get(Message, Key), OutData);
+		}
+
+		if (Message.contains(Key))
+		{
+			return Internal::DecodeBinary(Message[Key], OutData);
+			;
+		}
+		return false;
+	}
+
+	static void AppendBinary(ROSData &Message, const char *Key, const uint8 *InData, const uint32 DataLength)
+	{
+		const ROSData Data = ROSData(jsoncons::byte_string_arg, std::vector<uint8_t>(InData, InData + DataLength), jsoncons::semantic_tag::base64);
+
+		if (Key[0] == '/')
+		{
+			jsoncons::jsonpointer::insert_or_assign(Message, Key, Data);
+		}
+		else
+		{
+			Message.insert_or_assign(Key, Data);
+		}
+	}
+
+	/* Arrays */
+
+	template <typename T>
+	static bool ExtractTArrayOfUObjects(const ROSData &Message, const char *Key, TArray<T *> &Array, UObject *ParentObject, const TFunction<bool(const ROSData &, const char *, T *&)> &ExtractElement)
+	{
+		if (!Message.contains(Key) || !Message[Key].is_array())
+			return false;
+
+		Array.SetNum(Message[Key].size());
+
+		for (uint64 i = 0; i < Message[Key].size(); i++)
+		{
+			T *Temp = NewObject<T>(ParentObject); //Needs to be used for UObject
+			if (ExtractElement(Message[Key], ("/" + std::to_string(i)).c_str(), Temp))
+			{
+				Array[i] = MoveTempIfPossible(Temp);
+			}
+			else
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	template <typename T>
+	static bool ExtractTArray(const ROSData &Message, const char *Key, TArray<T> &Array, const TFunction<bool(const ROSData &, const char *, T &)> &ExtractElement)
+	{
+		if (!Message.contains(Key) || !Message[Key].is_array())
+			return false;
+
+		Array.SetNum(Message[Key].size());
+
+		for (uint64 i = 0; i < Message[Key].size(); i++)
+		{
+			T Temp;
+			if (ExtractElement(Message[Key], ("/" + std::to_string(i)).c_str(), Temp))
+			{
+				Array[i] = MoveTempIfPossible(Temp);
+			}
+			else
+			{
+				return false;
+			}
+		}
+		return true;
 	}
 }

--- a/Source/Rosbridge2Unreal/Public/DataHelpers.h
+++ b/Source/Rosbridge2Unreal/Public/DataHelpers.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <type_traits> // For is_base_of, unreal does not seem to have an equivalent
 #include "CoreMinimal.h"
 #include "TypeDefinitions.h"
+
+#include <type_traits>	  // For is_base_of, unreal does not seem to have an equivalent
 
 namespace DataHelpers
 {
@@ -10,7 +11,7 @@ namespace DataHelpers
 	namespace Internal
 	{
 		template <typename JSONType, typename UnrealType>
-		bool Extract(const ROSData &Message, const char *Key, UnrealType &OutData)
+		bool Extract(const ROSData& Message, const char* Key, UnrealType& OutData)
 		{
 			if (Key[0] == '/')
 			{
@@ -30,7 +31,7 @@ namespace DataHelpers
 		}
 
 		template <typename JSONType, typename UnrealType>
-		bool Append(ROSData &Message, const char *Key, const UnrealType &InData)
+		bool Append(ROSData& Message, const char* Key, const UnrealType& InData)
 		{
 			if (Key[0] == '/')
 			{
@@ -43,7 +44,7 @@ namespace DataHelpers
 			return false;
 		}
 
-		static bool DecodeBinary(const ROSData &Message, TArray<uint8> &OutData)
+		static bool DecodeBinary(const ROSData& Message, TArray<uint8>& OutData)
 		{
 			if (Message.is_byte_string_view()) /* Real byte string in BSON */
 			{
@@ -62,7 +63,7 @@ namespace DataHelpers
 		}
 
 		/* Just for debugging purposes */
-		static FString DataToString(const ROSData &Document)
+		static FString DataToString(const ROSData& Document)
 		{
 			std::string S;
 			Document.dump(S, jsoncons::indenting::indent);
@@ -76,11 +77,11 @@ namespace DataHelpers
 	template <>                                                                                   \
 	struct DataConverter<UnrealType>                                                              \
 	{                                                                                             \
-		static inline void Append(ROSData &OutMessage, const char *Key, const UnrealType &Value)  \
+		static inline void Append(ROSData& OutMessage, const char* Key, const UnrealType& Value)  \
 		{                                                                                         \
 			Internal::Append<InternalType>(OutMessage, Key, Value);                               \
 		}                                                                                         \
-		static inline bool Extract(const ROSData &Message, const char *Key, UnrealType &OutValue) \
+		static inline bool Extract(const ROSData& Message, const char* Key, UnrealType& OutValue) \
 		{                                                                                         \
 			return Internal::Extract<InternalType>(Message, Key, OutValue);                       \
 		}                                                                                         \
@@ -108,15 +109,15 @@ namespace DataHelpers
 		template <>
 		struct DataConverter<FString>
 		{
-			static inline void Append(ROSData &OutMessage, const char *Key, const FString &Value)
+			static inline void Append(ROSData& OutMessage, const char* Key, const FString& Value)
 			{
-				Internal::Append<const char *>(OutMessage, Key, TCHAR_TO_UTF8(*Value));
+				Internal::Append<const char*>(OutMessage, Key, TCHAR_TO_UTF8(*Value));
 			}
 
-			static inline bool Extract(const ROSData &Message, const char *Key, FString &OutValue)
+			static inline bool Extract(const ROSData& Message, const char* Key, FString& OutValue)
 			{
-				const char *CString;
-				if (Internal::Extract<const char *>(Message, Key, CString))
+				const char* CString;
+				if (Internal::Extract<const char*>(Message, Key, CString))
 				{
 					OutValue = UTF8_TO_TCHAR(CString);
 					return true;
@@ -132,14 +133,14 @@ namespace DataHelpers
 		template <typename T>
 		struct DataConverter<T*, typename TEnableIf<std::is_base_of<UROSMessageBase, T>::value>::Type>
 		{
-			static inline void Append(ROSData &OutMessage, const char *Key, const T* Message)
+			static inline void Append(ROSData& OutMessage, const char* Key, const T* Message)
 			{
 				ROSData Data;
 				Message->ToData(Data);
 				DataHelpers::Append<ROSData>(OutMessage, Key, Data);
 			}
 
-			static inline bool Extract(const ROSData &Message, const char *Key, T*& OutMessageInstance)
+			static inline bool Extract(const ROSData& Message, const char* Key, T*& OutMessageInstance)
 			{
 				if (OutMessageInstance == nullptr)
 				{
@@ -200,21 +201,21 @@ namespace DataHelpers
 			}
 		};
 
-	} // namespace Internal
+	}	 // namespace Internal
 
 	template <typename T>
-	inline void Append(ROSData &OutMessage, const char *Key, const T &Value)
+	inline void Append(ROSData& OutMessage, const char* Key, const T& Value)
 	{
 		Internal::DataConverter<T>::Append(OutMessage, Key, Value);
 	}
 
 	template <typename T>
-	inline bool Extract(const ROSData &Message, const char *Key, T &OutValue)
+	inline bool Extract(const ROSData& Message, const char* Key, T& OutValue)
 	{
 		return Internal::DataConverter<T>::Extract(Message, Key, OutValue);
 	}
 
-	static bool ExtractBinary(const ROSData &Message, const char *Key, TArray<uint8> &OutData)
+	static bool ExtractBinary(const ROSData& Message, const char* Key, TArray<uint8>& OutData)
 	{
 		if (Key[0] == '/')
 		{
@@ -229,9 +230,10 @@ namespace DataHelpers
 		return false;
 	}
 
-	static void AppendBinary(ROSData &Message, const char *Key, const uint8 *InData, const uint32 DataLength)
+	static void AppendBinary(ROSData& Message, const char* Key, const uint8* InData, const uint32 DataLength)
 	{
-		const ROSData Data = ROSData(jsoncons::byte_string_arg, std::vector<uint8_t>(InData, InData + DataLength), jsoncons::semantic_tag::base64);
+		const ROSData Data =
+			ROSData(jsoncons::byte_string_arg, std::vector<uint8_t>(InData, InData + DataLength), jsoncons::semantic_tag::base64);
 
 		if (Key[0] == '/')
 		{
@@ -242,4 +244,4 @@ namespace DataHelpers
 			Message.insert_or_assign(Key, Data);
 		}
 	}
-}
+}	 // namespace DataHelpers

--- a/Source/Rosbridge2Unreal/Public/Messages/geometry_msgs/ROSMsgPoseWithCovariance.h
+++ b/Source/Rosbridge2Unreal/Public/Messages/geometry_msgs/ROSMsgPoseWithCovariance.h
@@ -20,7 +20,7 @@ public:
 
 	/* Blueprint functions. Ease of use. Lowers the precision */
 	UFUNCTION(BlueprintCallable) TArray<float> CovarianceAsFloatArray() const;
-	UFUNCTION(BlueprintCallable) void SetCovarianceFromFloatArray(const TArray<float> InArray);
+	UFUNCTION(BlueprintCallable) void SetCovarianceFromFloatArray(const TArray<float>& InArray);
 	
 	/* Data */
 	/*

--- a/Source/Rosbridge2Unreal/Public/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.h
+++ b/Source/Rosbridge2Unreal/Public/Messages/geometry_msgs/ROSMsgPoseWithCovarianceStamped.h
@@ -19,9 +19,6 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure) static UROSMsgPoseWithCovarianceStamped* Create(UROSMsgHeader* Header, UROSMsgPoseWithCovariance* Pose);
 	UFUNCTION(BlueprintCallable, BlueprintPure) static UROSMsgPoseWithCovarianceStamped* CreateEmpty();
 	
-	UFUNCTION(BlueprintCallable, BlueprintPure) FVector GetPositionInUnrealCoordinateFrame() const;
-	UFUNCTION(BlueprintCallable, BlueprintPure) FQuat GetRotationInUnrealCoordinateFrame() const;
-	
 	/* Data */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) UROSMsgHeader* Header;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) UROSMsgPoseWithCovariance* Pose;

--- a/Source/Rosbridge2Unreal/Public/Messages/nav_msgs/ROSMsgPath.h
+++ b/Source/Rosbridge2Unreal/Public/Messages/nav_msgs/ROSMsgPath.h
@@ -20,7 +20,6 @@ public:
 	/* Data */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) UROSMsgHeader* Header;
 	UPROPERTY(EditAnywhere, BlueprintReadWrite) TArray<UROSMsgPoseStamped*> Poses;
-	UFUNCTION(BlueprintCallable) void AddPoseInUnrealCoordinateFrame(const FTransform& Transform, UROSMsgHeader* HeaderIn);
 
 	/* Transformation Functions */
 	void ToData(ROSData& OutMessage) const override;


### PR DESCRIPTION
This PR refactors the DataHelpers. The main goal was to be able to extract and append arrays without needing to provide a lambda to do the (de-)serialization.

The general syntax will change from
```c++
DataHelpers::AppendDouble(OutMessage, "x", X);
```
to
```c++
DataHelpers::Append<double>(OutMessage, "x", X);
```
The template parameter should be always deductable from the parameter type and, thus, is completely optional. It can be used to explicitely force a specific version of the function as this was a requirement based on previous discussions.

Extracting arrays is now simplified as:
```c++
DataHelpers::Append<TArray<double>>(OutMessage, "covariance", Covariance);
```
instead of
```c++
 DataHelpers::ExtractTArray<double>(Message, "covariance", Covariance, [](const ROSData& Array, const char* Key, double& Result)
	{
		return DataHelpers::ExtractDouble(Array, Key, Result);
	});
```
Again, template parameters are optional.

Usage with an undefined type leads to the following error (MSVC):
```
1>...\Plugins\Rosbridge2Unreal\Source\Rosbridge2Unreal\Public\DataHelpers.h(208): error C2027: use of undefined type 'DataHelpers::Internal::DataConverter<T,void>'
1>          with
1>          [
1>              T=SomeCustomType
1>          ]
```

**Discussion points**
* *Should we do such a change?* The data helpers now contain a little bit of template magic in the `DataConverter` struct to make it work. This, however, is also only necessary to be able to explicitely state the data type via a template parameter. We could get rid of the `DataConverter` completely by just using function overloading.
* *Should we leave in all old functions to ensure backwards compatibility?*
* If not: *Should we leave functions in to explicitely Append/Extract array elements?* First, I thought this would be a nice feature, but I failed to come up with a valid use case.

**ToDo**
* [x] Fix formatting. Accidently ran clang-format which messed up the formatting in DataHelpers.h and makes the git diff unreadable.
* [x] Extensive testing.